### PR TITLE
v1.7.0

### DIFF
--- a/2229460523/scripts/clientmenu.txt
+++ b/2229460523/scripts/clientmenu.txt
@@ -17781,7 +17781,7 @@
 	
 	"saved_line_menu1"
 	{	
-        "Title"     "Saved line and talking speed(used after starting to talk)"
+        "Title"     "Saved line and talking speed(use after talking starts)"
     
 		"1"
 		{
@@ -17813,9 +17813,60 @@
 			"command"	 "scripted_user_func pitch,1.0;show_menu saved_line_menu1"
 			"label"		 " x1.0 talking speed"
 		}
+		"7"
+		{
+			"command"	 "play buttons/button14;show_menu saved_line_menu2"
+			"label"		 " Permanent pitch shifts"
+		}
 		"8"
 		{
 				"command"	 "play buttons/button14;show_menu smok_menu"
+				"label"		 " << Back"
+		}
+		"0"
+		{
+				"command"    "play buttons/button14"
+				"label"      " Exit"
+		}
+	}
+
+	"saved_line_menu2"
+	{	
+        "Title"     "Saved line and talking speed(applied automatically)"
+    
+		"1"
+		{
+			"command"	 "play buttons/button14;scripted_user_func perma_pitch,0.4;show_menu saved_line_menu2"
+			"label"		 " x0.4 talking speed"
+		}
+		"2"
+		{
+			"command"	 "play buttons/button14;scripted_user_func perma_pitch,0.7;show_menu saved_line_menu2"
+			"label"		 " x0.7 talking speed"
+		}
+		"3"
+		{
+			"command"	 "play buttons/button14;scripted_user_func perma_pitch,1.3;show_menu saved_line_menu2"
+			"label"		 " x1.3 talking speed"
+		}
+		"4"
+		{
+			"command"	 "play buttons/button14;scripted_user_func perma_pitch,1.7;show_menu saved_line_menu2"
+			"label"		 " x1.7 talking speed"
+		}
+		"5"
+		{
+			"command"	 "scripted_user_func speak_saved;show_menu saved_line_menu2"
+			"label"		 " Speak saved line"
+		}
+		"6"
+		{
+			"command"	 "play buttons/button14;scripted_user_func perma_pitch,1.0;show_menu saved_line_menu2"
+			"label"		 " x1.0 talking speed (Reset)"
+		}
+		"8"
+		{
+				"command"	 "play buttons/button14;show_menu saved_line_menu1"
 				"label"		 " << Back"
 		}
 		"0"
@@ -28214,8 +28265,8 @@
 			"Title"     "More exterior stuff 1"
 			"1"
 			{
-					"command"    "play buttons/button14;scripted_user_func prop,dynamic,models/props_street/garbage_can.mdl;show_menu props_street1"
-					"label"      " Garbage can"
+					"command"    "play buttons/button14;show_menu props_streetgarbagecans1"
+					"label"      " Garbage cans"
 			}
 			"2"
 			{
@@ -28257,6 +28308,35 @@
 			{
 					"command"    "play buttons/button14;show_menu props_street2"
 					"label"      " >> Next"
+			}
+			"0"
+			{
+					"command"    "play buttons/button14"
+					"label"      " Exit"
+			}
+	}
+	"props_streetgarbagecans1"
+	{
+			"Title"     "Garbage cans/bins"
+			"1"
+			{
+					"command"    "play buttons/button14;scripted_user_func prop,dynamic,models/props_street/garbage_can.mdl;show_menu props_streetgarbagecans1"
+					"label"      " Garbage can"
+			}
+			"2"
+			{
+					"command"    "play buttons/button14;scripted_user_func prop,dynamic,models/props_street/trashbin01.mdl;show_menu props_streetgarbagecans1"
+					"label"      " Garbage bin green"
+			}
+			"3"
+			{
+					"command"    "play buttons/button14;scripted_user_func prop,dynamic,models/props_junk/trashbin01a.mdl;show_menu props_streetgarbagecans1"
+					"label"      " Garbage bin blue"
+			}
+			"8"
+			{
+					"command"    "play buttons/button14;show_menu props_street1"
+					"label"      " << Back"
 			}
 			"0"
 			{
@@ -34912,8 +34992,8 @@
 			"Title"     "More exterior stuff 1"
 			"1"
 			{
-					"command"    "play buttons/button14;scripted_user_func prop,physicsM,models/props_street/garbage_can.mdl;show_menu phys_props_street1"
-					"label"      " Garbage can"
+					"command"    "play buttons/button14;show_menu phys_props_streetgarbagecans1"
+					"label"      " Garbage cans"
 			}
 			"2"
 			{
@@ -34962,7 +35042,36 @@
 					"label"      " Exit"
 			}
 	}
-
+	
+	"phys_props_streetgarbagecans1"
+	{
+			"Title"     "Garbage cans/bins"
+			"1"
+			{
+					"command"    "play buttons/button14;scripted_user_func prop,physicsM,models/props_street/garbage_can.mdl;show_menu phys_props_streetgarbagecans1"
+					"label"      " Garbage can"
+			}
+			"2"
+			{
+					"command"    "play buttons/button14;scripted_user_func prop,physicsM,models/props_street/trashbin01.mdl;show_menu phys_props_streetgarbagecans1"
+					"label"      " Garbage bin green"
+			}
+			"3"
+			{
+					"command"    "play buttons/button14;scripted_user_func prop,physicsM,models/props_junk/trashbin01a.mdl;show_menu phys_props_streetgarbagecans1"
+					"label"      " Garbage bin blue"
+			}
+			"8"
+			{
+					"command"    "play buttons/button14;show_menu phys_props_street1"
+					"label"      " << Back"
+			}
+			"0"
+			{
+					"command"    "play buttons/button14"
+					"label"      " Exit"
+			}
+	}
 	"phys_props_street_tracks1"
 	{
 			"Title"     "Concrete tracks"
@@ -43153,8 +43262,8 @@
 			"Title"     "More exterior stuff 1"
 			"1"
 			{
-					"command"    "play buttons/button14;scripted_user_func model,!self,models/props_street/garbage_can.mdl;show_menu models_self_street1"
-					"label"      " Garbage can"
+					"command"    "play buttons/button14;show_menu models_self_streetgarbagecans1"
+					"label"      " Garbage cans"
 			}
 			"2"
 			{
@@ -43202,7 +43311,36 @@
 					"label"      " Exit"
 			}
 	}
-
+	
+	"models_self_streetgarbagecans1"
+	{
+			"Title"     "Garbage cans/bins"
+			"1"
+			{
+					"command"    "play buttons/button14;scripted_user_func model,!self,models/props_street/garbage_can.mdl;show_menu models_self_streetgarbagecans1"
+					"label"      " Garbage can"
+			}
+			"2"
+			{
+					"command"    "play buttons/button14;scripted_user_func model,!self,models/props_street/trashbin01.mdl;show_menu models_self_streetgarbagecans1"
+					"label"      " Garbage bin green"
+			}
+			"3"
+			{
+					"command"    "play buttons/button14;scripted_user_func model,!self,models/props_junk/trashbin01a.mdl;show_menu models_self_streetgarbagecans1"
+					"label"      " Garbage bin blue"
+			}
+			"8"
+			{
+					"command"    "play buttons/button14;show_menu models_self_street1"
+					"label"      " << Back"
+			}
+			"0"
+			{
+					"command"    "play buttons/button14"
+					"label"      " Exit"
+			}
+	}
 	"models_self_street_tracks1"
 	{
 			"Title"     "Concrete tracks"
@@ -49369,8 +49507,8 @@
 			"Title"     "More exterior stuff 1"
 			"1"
 			{
-					"command"    "play buttons/button14;scripted_user_func model,!picker,models/props_street/garbage_can.mdl;show_menu models_picker_street1"
-					"label"      " Garbage can"
+					"command"    "play buttons/button14;show_menu models_picker_streetgarbagecans1"
+					"label"      " Garbage cans"
 			}
 			"2"
 			{
@@ -49418,7 +49556,36 @@
 					"label"      " Exit"
 			}
 	}
-
+		
+	"models_picker_streetgarbagecans1"
+	{
+			"Title"     "Garbage cans/bins"
+			"1"
+			{
+					"command"    "play buttons/button14;scripted_user_func model,!picker,models/props_street/garbage_can.mdl;show_menu models_picker_streetgarbagecans1"
+					"label"      " Garbage can"
+			}
+			"2"
+			{
+					"command"    "play buttons/button14;scripted_user_func model,!picker,models/props_street/trashbin01.mdl;show_menu models_picker_streetgarbagecans1"
+					"label"      " Garbage bin green"
+			}
+			"3"
+			{
+					"command"    "play buttons/button14;scripted_user_func model,!picker,models/props_junk/trashbin01a.mdl;show_menu models_picker_streetgarbagecans1"
+					"label"      " Garbage bin blue"
+			}
+			"8"
+			{
+					"command"    "play buttons/button14;show_menu models_picker_street1"
+					"label"      " << Back"
+			}
+			"0"
+			{
+					"command"    "play buttons/button14"
+					"label"      " Exit"
+			}
+	}
 	"models_picker_street_tracks1"
 	{
 			"Title"     "Concrete tracks"

--- a/2229460523/scripts/vscripts/admin_system/vslib/entity.nut
+++ b/2229460523/scripts/vscripts/admin_system/vslib/entity.nut
@@ -4584,6 +4584,69 @@ function VSLib::Entity::IsCarryingItem()
 /*
  * @authors rhino
  */
+function VSLib::Entity::IsUseable()
+{
+	if (!IsEntityValid())
+	{
+		printl("VSLib Warning: Entity " + _idx + " is invalid.");
+		return false;
+	}
+	
+	return "PS_CurrentPointUseEntity" in GetScriptScope() && GetScriptScope()["PS_CurrentPointUseEntity"] != null && GetScriptScope()["PS_CurrentPointUseEntity"].IsEntityValid();
+}
+/*
+ * @authors rhino
+ */
+function VSLib::Entity::RemoveUseAbility()
+{
+	if (!IsEntityValid())
+	{
+		printl("VSLib Warning: Entity " + _idx + " is invalid.");
+		return false;
+	}
+	if(IsUseable())
+	{
+		GetScriptScope()["PS_CurrentPointUseEntity"].Kill()
+		GetScriptScope()["PS_CurrentPointUseEntity"] = null
+		return true
+	}
+	else
+		return false
+}
+/*
+ * @authors rhino
+ */
+function VSLib::Entity::IsLootable()
+{
+	if (!IsEntityValid())
+	{
+		printl("VSLib Warning: Entity " + _idx + " is invalid.");
+		return false;
+	}
+	
+	return "PS_LootPlaced" in GetScriptScope() && GetScriptScope()["PS_LootPlaced"];
+}
+/*
+ * @authors rhino
+ */
+function VSLib::Entity::RemoveLootAbility()
+{
+	if (!IsEntityValid())
+	{
+		printl("VSLib Warning: Entity " + _idx + " is invalid.");
+		return false;
+	}
+	if(IsLootable())
+	{
+		GetScriptScope()["PS_LootPlaced"] = false
+		return true
+	}
+	else
+		return false
+}
+/*
+ * @authors rhino
+ */
 function VSLib::Entity::HasRagdollPresent()
 {
 	if (!IsEntityValid())
@@ -4660,6 +4723,25 @@ function VSLib::Entity::IsGrabable()
 /*
  * @authors rhino
  */
+function VSLib::Entity::RemoveDriveAbility()
+{
+	if (!IsEntityValid())
+	{
+		printl("VSLib Warning: Entity " + _idx + " is invalid.");
+		return false;
+	}
+	if(HasDrivingAbility())
+	{
+		GetScriptScope()["PS_HAS_DRIVE_ABILITY"] <- false
+		return true
+	}
+	else
+		return false
+}
+
+/*
+ * @authors rhino
+ */
 function VSLib::Entity::HasDriver()
 {
 	if (!IsEntityValid())
@@ -4669,6 +4751,26 @@ function VSLib::Entity::HasDriver()
 	}
 	
 	return ("PS_HAS_DRIVER" in GetScriptScope()) && (GetScriptScope()["PS_HAS_DRIVER"])
+}
+
+/*
+ * @authors rhino
+ */
+function VSLib::Entity::HasPassenger()
+{
+	if (!IsEntityValid())
+	{
+		printl("VSLib Warning: Entity " + _idx + " is invalid.");
+		return false;
+	}
+	
+	foreach(survivor in Players.AliveSurvivors())
+	{
+		local v = survivor.GetPassengerVehicle()
+		if(v && v.GetEntityHandle() == GetEntityHandle())
+			return true
+	}
+	return false
 }
 
 /*

--- a/2229460523/scripts/vscripts/project_smok/adminvars.nut
+++ b/2229460523/scripts/vscripts/project_smok/adminvars.nut
@@ -346,15 +346,6 @@
         //Others
         if(basetbl != null)
         {
-            basetbl._RagdollControl[spec] <- 
-            {
-                keymask = 0
-                speed = 60.0
-                overridefriction = 0.3
-                frictionduration = 1
-                listenerid = -1
-            }
-
             basetbl._CurrentlyTradingItems[spec] <- false;
 
             basetbl.BotBringingItem[spec] <- false;

--- a/2229460523/scripts/vscripts/project_smok/constants.nut
+++ b/2229460523/scripts/vscripts/project_smok/constants.nut
@@ -5,8 +5,8 @@
 {
 	Version = 
 	{
-		Number = "v1.6.0"
-		Date = "21.04.2021"
+		Number = "v1.7.0"
+		Date = "29.04.2021"
 		Source = "https://github.com/semihM/project_smok"
 	}
 

--- a/2229460523/scripts/vscripts/project_smok/quicktimers.nut
+++ b/2229460523/scripts/vscripts/project_smok/quicktimers.nut
@@ -31,7 +31,7 @@
     e.SetName(Quix.TimerName+name)
 	e = e.GetBaseEntity()
 	
-	::Quix.Table[name] <- e.GetName()
+	::Quix.Table[name] <- e
 
     local interval = ::Quix.Interval
 	local scp = e.GetScriptScope()
@@ -98,7 +98,7 @@
     e.SetName(Quix.TimerName+name)
 	e = e.GetBaseEntity()
 	
-	::Quix.Table[name] <- e.GetName()
+	::Quix.Table[name] <- e
 
     local interval = ::Quix.Interval
 	local scp = e.GetScriptScope()
@@ -500,9 +500,17 @@
 {
     if(name in ::Quix.Table)
     {
-        foreach(obj in ::Quix.Table[name])
-		    DoEntFire("!self","Kill","",0,null,obj)
-		delete ::Quix.Table[name]
+        switch(typeof ::Quix.Table[name])
+        {
+            case "table":
+                foreach(obj in ::Quix.Table[name])
+                    DoEntFire("!self","Kill","",0,null,obj)
+                break;
+            default:
+                DoEntFire("!self","Kill","",0,null,::Quix.Table[name])
+                break;
+        }
+        delete ::Quix.Table[name]
     }
 	else
         printl(name+" doesn't exists!")

--- a/README.md
+++ b/README.md
@@ -1186,12 +1186,29 @@
    Console Syntax | scripted_user_func *pitch,speed*  
    ------------- | -------------
     
-   Menu Sequence | _6->5->5->1, 6->5->5->2, 6->5->5->3, 6->5->5->4 AND 6->5->5->6_
+   Menu Sequence | _6->5->1, 6->5->2, 6->5->3, 6->5->4 AND 6->5->6_
    ------------- | -------------
 ```cpp 
        //Overloads:
        // speed: Talking speed, default is 1.0
        pitch {speed: float}
+```
+---
+#### **perma_pitch**
+- Change the pitch(talking speed) of voice lines you speak automatically. Works similar to **pitch** except this doesn't require the player to be currently speaking.
+
+   Chat Syntax | (!,/,?)perma_pitch *speed*
+   ------------- | -------------
+
+   Console Syntax | scripted_user_func *perma_pitch,speed*  
+   ------------- | -------------
+    
+   Menu Sequence | _6->5->7->1, 6->5->7->2, 6->5->7->3, 6->5->7->4 AND 6->5->7->6_
+   ------------- | -------------
+```cpp 
+       //Overloads:
+       // speed: Talking speed, default is 1.0
+       perma_pitch {speed: float}
 ```
 ---
 #### **randomline_save_last**


### PR DESCRIPTION
## Additions
- New ragdolling mechanics with **non-human** models using [**go_ragdoll**](https://github.com/semihM/project_smok#user-content-go_ragdoll) command.

- [**perma_pitch**](https://github.com/semihM/project_smok#user-content-perma_pitch) command for chancing talking speed automatically instead of requiring the start of a line.

- Add **2** new trash bin models to menu

---
## Updates

- Enable facial expressions on ragdolling ragdolls

- Allow loot drops upon breaking breakable and lootable props

- Update the documentation and wiki tables

- Allow collisions of default vehicles to allow shooting and throwing grenades

- Include **2** new barrel models, exclude alarm car windows for looting

- Disable ragdolling while driving/being a passenger

- Disable driving/becoming a passenger/looting while ragdolling

---
## Fixes

- Fix some looting related issues

- Fix some small bugs