### PR TITLE
v2.1.0

### DIFF
--- a/2229460523/scripts/clientmenu.txt
+++ b/2229460523/scripts/clientmenu.txt
@@ -19102,7 +19102,7 @@
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random;show_menu random_line_menu"
+				"command"		 "scripted_user_func randomline,random;show_menu random_line_menu"
 				"label"			" Random person, own lines"
 			}
 			"5"
@@ -19112,7 +19112,7 @@
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,random;show_menu random_line_menu"
+				"command"		 "scripted_user_func randomline,random,random;show_menu random_line_menu"
 				"label"			" Random person, random lines"
 			}
 			"7"
@@ -19138,7 +19138,7 @@
 			
 			"1"
 			{
-				"command"	 "play buttons/button14;scripted_user_func randomline_save_last;show_menu random_line_settings_menu"
+				"command"	 "scripted_user_func randomline_save_last;show_menu random_line_settings_menu"
 				"label"		 " Enable/Disable saving last random line"
 			}
 			"2"
@@ -19205,12 +19205,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self;show_menu random_line_menu_p_p_sp"
+				"command"		 "scripted_user_func randomline,self;show_menu random_line_menu_p_p_sp"
 				"label"			" Self"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker;show_menu random_line_menu_p_p_sp"
+				"command"		 "scripted_user_func randomline,picker;show_menu random_line_menu_p_p_sp"
 				"label"			" Picker"
 			}
 			"3"
@@ -19236,12 +19236,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick;show_menu random_line_menu_p_p_nb"
+				"command"		 "scripted_user_func randomline,nick;show_menu random_line_menu_p_p_nb"
 				"label"			" Nick"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill;show_menu random_line_menu_p_p_nb"
+				"command"		 "scripted_user_func randomline,bill;show_menu random_line_menu_p_p_nb"
 				"label"			" Bill"
 			}
 			"8"
@@ -19262,12 +19262,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis;show_menu random_line_menu_p_p_ef"
+				"command"		 "scripted_user_func randomline,ellis;show_menu random_line_menu_p_p_ef"
 				"label"			" Ellis"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis;show_menu random_line_menu_p_p_ef"
+				"command"		 "scripted_user_func randomline,francis;show_menu random_line_menu_p_p_ef"
 				"label"			" Francis"
 			}
 			"8"
@@ -19288,12 +19288,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle;show_menu random_line_menu_p_p_rz"
+				"command"		 "scripted_user_func randomline,rochelle;show_menu random_line_menu_p_p_rz"
 				"label"			" Rochelle"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey;show_menu random_line_menu_p_p_rz"
+				"command"		 "scripted_user_func randomline,zoey;show_menu random_line_menu_p_p_rz"
 				"label"			" Zoey"
 			}
 			"8"
@@ -19314,12 +19314,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach;show_menu random_line_menu_p_p_cl"
+				"command"		 "scripted_user_func randomline,coach;show_menu random_line_menu_p_p_cl"
 				"label"			" Coach"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis;show_menu random_line_menu_p_p_cl"
+				"command"		 "scripted_user_func randomline,louis;show_menu random_line_menu_p_p_cl"
 				"label"			" Louis"
 			}
 			"8"
@@ -19412,42 +19412,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,bill;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,bill;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,nick;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,nick;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,francis;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,francis;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,ellis;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,ellis;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,louis;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,louis;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,coach;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,coach;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,zoey;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,zoey;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,rochelle;show_menu random_line_menu_p_o_sp_self"
+				"command"		 "scripted_user_func randomline,self,rochelle;show_menu random_line_menu_p_o_sp_self"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19469,42 +19469,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,bill;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,bill;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,nick;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,nick;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,francis;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,francis;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,ellis;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,ellis;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,louis;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,louis;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,coach;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,coach;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,zoey;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,zoey;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,rochelle;show_menu random_line_menu_p_o_sp_picker"
+				"command"		 "scripted_user_func randomline,picker,rochelle;show_menu random_line_menu_p_o_sp_picker"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19552,42 +19552,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,bill;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,bill;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,nick;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,nick;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,francis;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,francis;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,ellis;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,ellis;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,louis;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,louis;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,coach;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,coach;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,zoey;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,zoey;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,rochelle;show_menu random_line_menu_p_o_nb_nick"
+				"command"		 "scripted_user_func randomline,nick,rochelle;show_menu random_line_menu_p_o_nb_nick"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19609,42 +19609,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,bill;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,bill;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,nick;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,nick;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,francis;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,francis;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,ellis;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,ellis;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,louis;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,louis;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,coach;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,coach;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,zoey;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,zoey;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,rochelle;show_menu random_line_menu_p_o_nb_bill"
+				"command"		 "scripted_user_func randomline,bill,rochelle;show_menu random_line_menu_p_o_nb_bill"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19691,42 +19691,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,bill;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,bill;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,nick;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,nick;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,francis;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,francis;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,ellis;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,ellis;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,louis;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,louis;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,coach;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,coach;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,zoey;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,zoey;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,rochelle;show_menu random_line_menu_p_o_ef_ellis"
+				"command"		 "scripted_user_func randomline,ellis,rochelle;show_menu random_line_menu_p_o_ef_ellis"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19748,42 +19748,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,bill;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,bill;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,nick;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,nick;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,francis;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,francis;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,ellis;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,ellis;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,louis;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,louis;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,coach;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,coach;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,zoey;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,zoey;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,rochelle;show_menu random_line_menu_p_o_ef_francis"
+				"command"		 "scripted_user_func randomline,francis,rochelle;show_menu random_line_menu_p_o_ef_francis"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19831,42 +19831,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,bill;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,bill;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,nick;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,nick;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,francis;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,francis;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,ellis;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,ellis;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,louis;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,louis;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,coach;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,coach;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,zoey;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,zoey;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,rochelle;show_menu random_line_menu_p_o_rz_rochelle"
+				"command"		 "scripted_user_func randomline,rochelle,rochelle;show_menu random_line_menu_p_o_rz_rochelle"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19888,42 +19888,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,bill;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,bill;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,nick;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,nick;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,francis;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,francis;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,ellis;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,ellis;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,louis;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,louis;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,coach;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,coach;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,zoey;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,zoey;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,rochelle;show_menu random_line_menu_p_o_rz_zoey"
+				"command"		 "scripted_user_func randomline,zoey,rochelle;show_menu random_line_menu_p_o_rz_zoey"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -19972,42 +19972,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,bill;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,bill;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,nick;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,nick;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,francis;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,francis;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,ellis;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,ellis;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,louis;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,louis;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,coach;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,coach;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,zoey;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,zoey;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,rochelle;show_menu random_line_menu_p_o_cl_coach"
+				"command"		 "scripted_user_func randomline,coach,rochelle;show_menu random_line_menu_p_o_cl_coach"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -20029,42 +20029,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,bill;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,bill;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,nick;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,nick;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,francis;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,francis;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,ellis;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,ellis;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,louis;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,louis;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,coach;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,coach;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,zoey;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,zoey;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,rochelle;show_menu random_line_menu_p_o_cl_louis"
+				"command"		 "scripted_user_func randomline,louis,rochelle;show_menu random_line_menu_p_o_cl_louis"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -20127,12 +20127,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,self,random;show_menu random_line_menu_p_r_sp"
+				"command"		 "scripted_user_func randomline,self,random;show_menu random_line_menu_p_r_sp"
 				"label"			" Self"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,picker,random;show_menu random_line_menu_p_r_sp"
+				"command"		 "scripted_user_func randomline,picker,random;show_menu random_line_menu_p_r_sp"
 				"label"			" Picker"
 			}
 			"3"
@@ -20158,12 +20158,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,nick,random;show_menu random_line_menu_p_r_nb"
+				"command"		 "scripted_user_func randomline,nick,random;show_menu random_line_menu_p_r_nb"
 				"label"			" Nick"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,bill,random;show_menu random_line_menu_p_r_nb"
+				"command"		 "scripted_user_func randomline,bill,random;show_menu random_line_menu_p_r_nb"
 				"label"			" Bill"
 			}
 			"8"
@@ -20184,12 +20184,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,ellis,random;show_menu random_line_menu_p_r_ef"
+				"command"		 "scripted_user_func randomline,ellis,random;show_menu random_line_menu_p_r_ef"
 				"label"			" Ellis"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,francis,random;show_menu random_line_menu_p_r_ef"
+				"command"		 "scripted_user_func randomline,francis,random;show_menu random_line_menu_p_r_ef"
 				"label"			" Francis"
 			}
 			"8"
@@ -20210,12 +20210,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,rochelle,random;show_menu random_line_menu_p_r_rz"
+				"command"		 "scripted_user_func randomline,rochelle,random;show_menu random_line_menu_p_r_rz"
 				"label"			" Rochelle"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,zoey,random;show_menu random_line_menu_p_r_rz"
+				"command"		 "scripted_user_func randomline,zoey,random;show_menu random_line_menu_p_r_rz"
 				"label"			" Zoey"
 			}
 			"8"
@@ -20236,12 +20236,12 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,coach,random;show_menu random_line_menu_p_r_cl"
+				"command"		 "scripted_user_func randomline,coach,random;show_menu random_line_menu_p_r_cl"
 				"label"			" Coach"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,louis,random;show_menu random_line_menu_p_r_cl"
+				"command"		 "scripted_user_func randomline,louis,random;show_menu random_line_menu_p_r_cl"
 				"label"			" Louis"
 			}
 			"8"
@@ -20262,42 +20262,42 @@
 
 			"1"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,bill;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,bill;show_menu random_line_menu_r_o"
 				"label"			" Bill"
 			}
 			"2"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,nick;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,nick;show_menu random_line_menu_r_o"
 				"label"			" Nick"
 			}
 			"3"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,francis;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,francis;show_menu random_line_menu_r_o"
 				"label"			" Francis"
 			}
 			"4"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,ellis;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,ellis;show_menu random_line_menu_r_o"
 				"label"			" Ellis"
 			}
 			"5"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,louis;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,louis;show_menu random_line_menu_r_o"
 				"label"			" Louis"
 			}
 			"6"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,coach;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,coach;show_menu random_line_menu_r_o"
 				"label"			" Coach"
 			}
 			"7"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,zoey;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,zoey;show_menu random_line_menu_r_o"
 				"label"			" Zoey"
 			}
 			"8"
 			{
-				"command"		 "play buttons/button14;scripted_user_func randomline,random,rochelle;show_menu random_line_menu_r_o"
+				"command"		 "scripted_user_func randomline,random,rochelle;show_menu random_line_menu_r_o"
 				"label"			" Rochelle"
 			}
 			"9"
@@ -20382,6 +20382,11 @@
 			{
 				"command"		 "play buttons/button14;show_menu ent_fire_decals1"
 				"label"			 " Place decals"
+			}
+			"3"
+			{
+				"command"		 "play buttons/button14;show_menu ent_fire_lootables1"
+				"label"			 " Make props lootable"
 			}
 			"8"
 			{
@@ -39655,12 +39660,12 @@
 			"1"
 			{
 				"command"		 "play buttons/button14;scripted_user_func go_ragdoll;show_menu ragdolling_menu1"
-				"label"			 " Go ragdolling"
+				"label"			 " Start/stop ragdolling"
 			}
 			"2"
 			{
 				"command"		 "play buttons/button14;scripted_user_func recover_ragdoll;show_menu ragdolling_menu1"
-				"label"			 " Recover from ragdolling"
+				"label"			 " Stop ragdolling"
 			}
 			"3"
 			{

--- a/2229460523/scripts/vscripts/admin_system.nut
+++ b/2229460523/scripts/vscripts/admin_system.nut
@@ -1273,7 +1273,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 		return
 	}
 
-	if(!(lvl = ::UserLevelUtils.ValidateLevel(player, GetArgument(2), false)))
+	if(!(lvl = ::UserLevelUtils.ValidateLevel(player, GetArgument(2), false, true)))
 		return
 	
 	::PrivilegeRequirements[cmd] <- getconsttable()[lvl]
@@ -13599,14 +13599,46 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 		return Target
 	}
 
-	ValidateLevel = function(player, lvlname, user = true)
+	ValidateLevel = function(player, lvlname, user = true, allow_alt = false)
 	{
 		if(Utils.GetIDFromArray(::UserLevelNames,lvlname) == -1)
 		{
-			::Printer(player,"Unknown user level: "+lvlname,"error");
-			return false
+			local valid = false
+			if(allow_alt)
+			{
+				switch(strip(lvlname.tolower()))
+				{
+					case "none":
+						lvlname = "PS_USER_NONE";
+						valid = true;
+						break;
+					case "basic": 
+						lvlname = "PS_USER_BASIC";
+						valid = true;
+						break;
+					case "admin": 
+						lvlname = "PS_USER_ADMIN";
+						valid = true;
+						break;
+					case "scripter": 
+						lvlname = "PS_USER_SCRIPTER";
+						valid = true;
+						break;
+					case "host": 
+						lvlname = "PS_USER_HOST";
+						valid = true;
+						break;
+				}
+			}
+
+			if(!valid)
+			{
+				::Printer(player,"Unknown user level: "+lvlname,"error");
+				return false
+			}
 		}
-		else if(user && lvlname == "PS_USER_HOST")
+		
+		if(user && lvlname == "PS_USER_HOST")
 		{
 			if(!player.HasPrivilege(PS_USER_HOST))
 				::Messages.ThrowPlayer(player,"Can't give host privilages to other players!")
@@ -13642,7 +13674,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 {	
 	local target, lvlname;
 	if(!(target = ::UserLevelUtils.GetValidateChangeTarget(player, GetArgument(1)))
-		|| !(lvlname = ::UserLevelUtils.ValidateLevel(player, GetArgument(2), false)))
+		|| !(lvlname = ::UserLevelUtils.ValidateLevel(player, GetArgument(2), false, true)))
 		return
 
 	::UserLevelUtils.Finalize(player, target, lvlname);

--- a/2229460523/scripts/vscripts/admin_system.nut
+++ b/2229460523/scripts/vscripts/admin_system.nut
@@ -114,7 +114,7 @@ if(!("date" in getroottable()))
 		}
 		catch(e)
 		{
-			printl("[DATE-ERROR] date() failed")
+			printR("[DATE-ERROR] date() failed")
 			local d = 
 			{
 				year = 2021
@@ -204,7 +204,7 @@ if("date" in getroottable())
 	}
 	catch(_err)
 	{
-		printl("[DATE-ERROR] date() failed")
+		printR("[DATE-ERROR] date() failed")
 		::AdminSystem.StartTime <- 
 		{
 			year = 2021
@@ -295,7 +295,7 @@ if("date" in getroottable())
 	local filelist = FileToString(Constants.Directories.CustomHooks);	// List of files
 	if(filelist == null)
 	{
-		printl("[Custom-Hooks] Creating "+Constants.Directories.CustomHooks+" for the first time...")
+		printR("[Custom-Hooks] Creating "+Constants.Directories.CustomHooks+" for the first time...")
 		StringToFile(Constants.Directories.CustomHooks,Constants.CustomHookListDefaults);
 		filelist = FileToString(Constants.Directories.CustomHooks);
 	}
@@ -303,7 +303,7 @@ if("date" in getroottable())
 	local example = FileToString(Constants.Directories.CustomHooksExample);	// Example
 	if(example == null)
 	{
-		printl("[Custom-Hooks] Creating "+Constants.Directories.CustomHooksExample+" for the first time...")
+		printR("[Custom-Hooks] Creating "+Constants.Directories.CustomHooksExample+" for the first time...")
 		StringToFile(Constants.Directories.CustomHooksExample,Constants.CustomHookDefaults);
 		example = FileToString(Constants.Directories.CustomHooksExample);
 	}
@@ -337,13 +337,13 @@ if("date" in getroottable())
 	{
 		if(!(eventname in ::VSLib.EasyLogic.Notifications))
 		{
-			printl("[Event-Hook-Unknown] "+eventname+" is unknown! Consider checking given links in the example file!")
+			printR("[Event-Hook-Unknown] "+eventname+" is unknown! Consider checking given links in the example file!")
 		}
 		else
 		{
 			if(typeof funcs != "table")
 			{
-				printl("[Event-Hook-Error] Event hooks for "+eventname+ " were formatted incorrectly! Format is-> PS_Hooks.On{GameEvent}.{FunctionName}<-function(param_1,param_2,...){}")
+				printR("[Event-Hook-Error] Event hooks for "+eventname+ " were formatted incorrectly! Format is-> PS_Hooks.On{GameEvent}.{FunctionName}<-function(param_1,param_2,...){}")
 			}
 			else
 			{
@@ -355,7 +355,7 @@ if("date" in getroottable())
 			}
 		}
 	}
-	printl("[Custom-Hooks] Found "+::PS_Hooks.len()+" events and a total of "+total+" hooks")
+	printR("[Custom-Hooks] Found "+::PS_Hooks.len()+" events and a total of "+total+" hooks")
 	printl("---------------------------------------------------------")
 }
 
@@ -368,7 +368,7 @@ if("date" in getroottable())
 	local filelist = FileToString(Constants.Directories.CommandScripts);	// List of files
 	if(filelist == null)
 	{
-		printl("[Custom-Scripts] Creating "+Constants.Directories.CommandScripts+" for the first time...")
+		printR("[Custom-Scripts] Creating "+Constants.Directories.CommandScripts+" for the first time...")
 		StringToFile(Constants.Directories.CommandScripts,Constants.CommandScriptListDefaults);
 		filelist = FileToString(Constants.Directories.CommandScripts);
 	}
@@ -376,7 +376,7 @@ if("date" in getroottable())
 	local example = FileToString(Constants.Directories.CommandScriptsExample);	// Example
 	if(example == null)
 	{
-		printl("[Custom-Scripts] Creating "+Constants.Directories.CommandScriptsExample+" for the first time...")
+		printR("[Custom-Scripts] Creating "+Constants.Directories.CommandScriptsExample+" for the first time...")
 		StringToFile(Constants.Directories.CommandScriptsExample,Constants.CommandScriptDefaults);
 		example = FileToString(Constants.Directories.CommandScriptsExample);
 	}
@@ -405,26 +405,26 @@ if("date" in getroottable())
 		compilestring(fileContents)();
 	}
 
-	printl("[Custom-Scripts] Reading custom command files...")
+	printR("[Custom-Scripts] Reading custom command files...")
 	local loaded = {}
 	local i = 0
 	foreach(cmdname, cmdtable in ::PS_Scripts)
 	{	
 		if(cmdname in ::AliasCompiler.ForbiddenAliasNames)	// Forbidden named
 		{
-			printl("[Forbidden-Name] Command name can not be "+cmdname+". Consider changing it!")
+			printR("[Forbidden-Name] Command name can not be "+cmdname+". Consider changing it!")
 			continue;
 		}
 		if(cmdname in ::ChatTriggers && !(cmdname in ::AliasCompiler.Tables || cmdname in ::PS_PreviousScriptsNames)) // Already a built-in trigger and wasn't custom alias or command
 		{
-			printl("[Command-Duplicate] Command name can not be "+cmdname+". Consider changing it!")
+			printR("[Command-Duplicate] Command name can not be "+cmdname+". Consider changing it!")
 			continue;
 		}
 		else
 		{
 			if(cmdname in ::AliasCompiler.Tables) // Was custom command or alias
 			{
-				printl("[Command-Reload] "+cmdname+" already exists! Overwriting it...")
+				printR("[Command-Reload] "+cmdname+" already exists! Overwriting it...")
 			}
 			local prv = PS_USER_NONE
 			if("MinimumUserLevel" in cmdtable && typeof cmdtable.MinimumUserLevel == "integer")
@@ -432,7 +432,7 @@ if("date" in getroottable())
 				prv = cmdtable.MinimumUserLevel
 				if(prv < PS_USER_NONE || prv > ::UserLevelNames.len())
 				{
-					printl("[Command-User-Level-Error] "+cmdname+" command's minimum user level is unknown! Allowing it's use for everyone");
+					printR("[Command-User-Level-Error] "+cmdname+" command's minimum user level is unknown! Allowing it's use for everyone");
 					prv = PS_USER_NONE
 				}
 			}
@@ -455,7 +455,7 @@ if("date" in getroottable())
 	}
 
 	if(loaded.len() > 0)
-		printl("[Custom-Commands] Loaded "+loaded.len()+" custom commands:")
+		printR("[Custom-Commands] Loaded "+loaded.len()+" custom commands:")
 	foreach(i,name in loaded)
 	{
 		printl("\t["+i+"] "+name)
@@ -535,7 +535,7 @@ if("date" in getroottable())
 	local filelist = FileToString(Constants.Directories.CommandAliases);	// List of files
 	if(filelist == null)
 	{
-		printl("[Custom-Aliases] Creating "+Constants.Directories.CommandAliases+" for the first time...")
+		printR("[Custom-Aliases] Creating "+Constants.Directories.CommandAliases+" for the first time...")
 		StringToFile(Constants.Directories.CommandAliases,Constants.CommandAliasesListDefaults);
 		filelist = FileToString(Constants.Directories.CommandAliases);
 	}
@@ -543,7 +543,7 @@ if("date" in getroottable())
 	local example = FileToString(Constants.Directories.CommandAliasesExample);	// Example v100
 	if(example == null)
 	{
-		printl("[Alias-Examples] Creating v1.0.0 examples in "+Constants.Directories.CommandAliasesExample+" for the first time...")
+		printR("[Alias-Examples] Creating v1.0.0 examples in "+Constants.Directories.CommandAliasesExample+" for the first time...")
 		StringToFile(Constants.Directories.CommandAliasesExample,Constants.CommandAliasesDefaults.v1_0_0);
 		example = FileToString(Constants.Directories.CommandAliasesExample);
 	}
@@ -556,7 +556,7 @@ if("date" in getroottable())
 		local ex = FileToString(pth);
 		if(ex == null)
 		{
-			printl("[Alias-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
+			printR("[Alias-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
 			StringToFile(pth,Constants.CommandAliasesDefaults[cleanvers]);
 			ex = FileToString(pth);
 		}
@@ -587,7 +587,7 @@ if("date" in getroottable())
 	}
 	
 	printl("---------------------------------------------------------")
-	printl("[Custom-Aliases] Aliased commands for this session ("+::AliasCompiler.Tables.len()+")")
+	printR("[Custom-Aliases] Aliased commands for this session ("+::AliasCompiler.Tables.len()+")")
 	local i = 0;
 	foreach(name,al in ::AliasCompiler.Tables)
 	{
@@ -605,7 +605,7 @@ if("date" in getroottable())
 	local fileContents = FileToString(Constants.Directories.LootTables);
 	if(fileContents == null)
 	{
-		printl("[Loot-Tables] Creating "+Constants.Directories.LootTables+" for the first time...")
+		printR("[Loot-Tables] Creating "+Constants.Directories.LootTables+" for the first time...")
 		StringToFile(Constants.Directories.LootTables,strip(Constants.LootSourcesLootTablesDefaults));
 		fileContents = FileToString(Constants.Directories.LootTables);
 	}
@@ -616,26 +616,26 @@ if("date" in getroottable())
 	}
 	catch(e)
 	{
-		printl("[Loot-Tables-Error] File format was invalid, using default loots! Error: "+e)
+		printR("[Loot-Tables-Error] File format was invalid, using default loots! Error: "+e)
 		::AdminSystem.LootSourcesLootTables <- null
 		return null;
 	}
 
 	if(arr == null || typeof arr != "array")
 	{
-		printl("[Loot-Tables-Error] File format was invalid, using default loots!")
+		printR("[Loot-Tables-Error] File format was invalid, using default loots!")
 		::AdminSystem.LootSourcesLootTables <- null
 		return null;
 	}
 	else
 	{
 		local valid_arr = []
-		printl("[Loot-Tables-Checks] Doing loot table checks...")
+		printR("[Loot-Tables-Checks] Doing loot table checks...")
 		foreach(i,tbl in arr)
 		{
 			if(typeof tbl != "table")
 			{
-				printl("[Loot-Tables-Error] File should contain tables seperated with commas! Using default loots!")
+				printR("[Loot-Tables-Error] File should contain tables seperated with commas! Using default loots!")
 				::AdminSystem.LootSourcesLootTables <- null
 				return null;
 			}
@@ -643,12 +643,12 @@ if("date" in getroottable())
 			{
 				if(!("ent" in tbl))
 				{
-					printl("[Loot-Tables-Warning] There is a table missing \"ent\" entry, skipping the table")
+					printR("[Loot-Tables-Warning] There is a table missing \"ent\" entry, skipping the table")
 					continue
 				}
 				if(!("prob" in tbl))
 				{
-					printl("[Loot-Tables-Warning] There is a table missing \"prob\" entry, skipping the table")
+					printR("[Loot-Tables-Warning] There is a table missing \"prob\" entry, skipping the table")
 					continue
 				}
 				if(!("ammo" in tbl))
@@ -665,7 +665,7 @@ if("date" in getroottable())
 			}
 		}
 		::AdminSystem.LootSourcesLootTables <- valid_arr
-		printl("[Loot-Tables-Checks] Completed checks and loaded the loot tables")
+		printR("[Loot-Tables-Checks] Completed checks and loaded the loot tables")
 	}
 }
 
@@ -770,7 +770,7 @@ function Notifications::OnPlayerConnected::ProcessQuixBinds(player,args)
 	local steamid = player.GetSteamID()
 	if("CustomBindsTable" in AdminSystem)
 	{
-		printl("[Binds-Process] Processing binds for "+player.GetName()+format("(%s)",steamid))
+		printR("[Binds-Process] Processing binds for "+player.GetName()+format("(%s)",steamid))
 		if(steamid in AdminSystem.CustomBindsTable)
 		{
 			foreach(key,keytbl in AdminSystem.CustomBindsTable[steamid])
@@ -798,7 +798,7 @@ function Notifications::OnPlayerLeft::RemoveQuixBinds(player, name, steamID, par
 	{
 		if(steamID in AdminSystem.CustomBindsTable)
 		{
-			printl("[Binds-Removal] Removing personal binds for "+name)
+			printR("[Binds-Removal] Removing personal binds for "+name)
 			foreach(key,keytbl in AdminSystem.CustomBindsTable[steamID])
 			{
 				foreach(func,tbl in keytbl)
@@ -810,7 +810,7 @@ function Notifications::OnPlayerLeft::RemoveQuixBinds(player, name, steamID, par
 
 		if("all" in AdminSystem.CustomBindsTable)
 		{
-			printl("[Binds-Removal] Removing global binds for "+name)
+			printR("[Binds-Removal] Removing global binds for "+name)
 			foreach(key,keytbl in AdminSystem.CustomBindsTable.all)
 			{
 				foreach(func,tbl in keytbl)
@@ -833,7 +833,7 @@ function Notifications::OnPlayerReplacedBot::ProcessQuixBinds(player,bot,args)
 	local steamid = player.GetSteamID()
 	if("CustomBindsTable" in AdminSystem)
 	{
-		printl("[Binds-Process] Processing binds for "+player.GetName()+format("(%s)",steamid))
+		printR("[Binds-Process] Processing binds for "+player.GetName()+format("(%s)",steamid))
 		if(steamid in AdminSystem.CustomBindsTable)
 		{
 			foreach(key,keytbl in AdminSystem.CustomBindsTable[steamid])
@@ -866,7 +866,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 			
 			if(steamID in AdminSystem.CustomBindsTable)
 			{
-				printl("[Binds-Removal] Removing personal binds for "+name)
+				printR("[Binds-Removal] Removing personal binds for "+name)
 				foreach(key,keytbl in AdminSystem.CustomBindsTable[steamID])
 				{
 					foreach(func,tbl in keytbl)
@@ -878,7 +878,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 
 			if("all" in AdminSystem.CustomBindsTable)
 			{
-				printl("[Binds-Removal] Removing global binds for "+name)
+				printR("[Binds-Removal] Removing global binds for "+name)
 				foreach(key,keytbl in AdminSystem.CustomBindsTable.all)
 				{
 					foreach(func,tbl in keytbl)
@@ -899,7 +899,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local filelist = FileToString(Constants.Directories.CustomBinds);	// List of files
 	if(filelist == null)
 	{
-		printl("[Custom-Binds] Creating "+Constants.Directories.CustomBinds+" for the first time...")
+		printR("[Custom-Binds] Creating "+Constants.Directories.CustomBinds+" for the first time...")
 		StringToFile(Constants.Directories.CustomBinds,strip(Constants.CustomBindsListDefaults));
 		filelist = FileToString(Constants.Directories.CustomBinds);
 	}
@@ -907,7 +907,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local example = FileToString(Constants.Directories.CustomBindsExample);	// Example v150
 	if(example == null)
 	{
-		printl("[Binds-Examples] Creating v1.5.0 examples in "+Constants.Directories.CustomBindsExample+" for the first time...")
+		printR("[Binds-Examples] Creating v1.5.0 examples in "+Constants.Directories.CustomBindsExample+" for the first time...")
 		StringToFile(Constants.Directories.CustomBindsExample,strip(Constants.CustomBindsTableDefaults.v1_5_0));
 		example = FileToString(Constants.Directories.CustomBindsExample);
 	}
@@ -920,7 +920,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	// 	local ex = FileToString(pth);
 	// 	if(ex == null)
 	// 	{
-	// 		printl("[Binds-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
+	// 		printR("[Binds-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
 	// 		StringToFile(pth,Constants.CustomBindsTableDefaults[cleanvers]);
 	// 		ex = FileToString(pth);
 	// 	}
@@ -1008,7 +1008,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local filelist = FileToString(Constants.Directories.CustomProps);	// List of files
 	if(filelist == null)
 	{
-		printl("[Custom-Entity_Groups] Creating "+Constants.Directories.CustomProps+" for the first time...")
+		printR("[Custom-Entity_Groups] Creating "+Constants.Directories.CustomProps+" for the first time...")
 		StringToFile(Constants.Directories.CustomProps,strip(Constants.CustomPropsListDefaults));
 		filelist = FileToString(Constants.Directories.CustomProps);
 	}
@@ -1016,7 +1016,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local example = FileToString(Constants.Directories.CustomPropsExample);	// Example v140
 	if(example == null)
 	{
-		printl("[Entity_Groups-Examples] Creating v1.4.0 examples in "+Constants.Directories.CustomPropsExample+" for the first time...")
+		printR("[Entity_Groups-Examples] Creating v1.4.0 examples in "+Constants.Directories.CustomPropsExample+" for the first time...")
 		StringToFile(Constants.Directories.CustomPropsExample,strip(Constants.CustomPropsDefaults.v1_4_0));
 		example = FileToString(Constants.Directories.CustomPropsExample);
 	}
@@ -1029,7 +1029,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 		local ex = FileToString(pth);
 		if(ex == null)
 		{
-			printl("[Alias-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
+			printR("[Alias-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
 			StringToFile(pth,Constants.CustomPropsDefaults[cleanvers]);
 			ex = FileToString(pth);
 		}
@@ -1107,7 +1107,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local fileContents = FileToString(Constants.Directories.DisabledCommands);
 	if(fileContents == null)
 	{
-		printl("[Command-Limits] Creating disabled_commands.txt for the first time...")
+		printR("[Command-Limits] Creating disabled_commands.txt for the first time...")
 		StringToFile(Constants.Directories.DisabledCommands,Constants.DisabledCommandsDefaults);
 		fileContents = FileToString(Constants.Directories.DisabledCommands);
 	}
@@ -1133,7 +1133,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 			if(!missingfound)
 			{
 				missingfound = true
-				printl("[Command-Limits] Found unknown command names in the disabled_commands.txt, consider removing them to save space:")
+				printR("[Command-Limits] Found unknown command names in the disabled_commands.txt, consider removing them to save space:")
 			}
 			printl("\t[Row "+(i+1)+"] "+cmd)
 		}
@@ -1142,7 +1142,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	if(::VSLib.EasyLogic.DisabledCommands.len() > 0)
 	{	
 		printl("---------------------------------------------------------")
-		printl("[Command-Limits] Disabled commands for this session ("+::VSLib.EasyLogic.DisabledCommands.len()+"):")
+		printR("[Command-Limits] Disabled commands for this session ("+::VSLib.EasyLogic.DisabledCommands.len()+"):")
 		local i = 0;
 		foreach(cmd,_v in ::VSLib.EasyLogic.DisabledCommands)
 		{
@@ -1288,7 +1288,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local fileContents = FileToString(Constants.Directories.CommandPrivileges);
 	if(fileContents == null)
 	{
-		printl("[Command-Privileges] Creating command_privileges.txt for the first time...")
+		printR("[Command-Privileges] Creating command_privileges.txt for the first time...")
 		StringToFile(Constants.Directories.CommandPrivileges,Constants.CommandPrivilegesDefault + "\r\n\r\n\r\n\r\n\r\n\r\n\r\n");
 		fileContents = FileToString(Constants.Directories.CommandPrivileges);
 	}
@@ -1332,7 +1332,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 	local fileContents = FileToString(Constants.Directories.CommandRestrictions);
 	if(fileContents == null)
 	{
-		printl("[Command-Limits] Creating command_limits.txt for the first time...")
+		printR("[Command-Limits] Creating command_limits.txt for the first time...")
 		StringToFile(Constants.Directories.CommandRestrictions,Constants.CommandRestrictionsDefault);
 		fileContents = FileToString(Constants.Directories.CommandRestrictions);
 	}
@@ -1366,7 +1366,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 		
 		if ( searchForHost == true && AdminSystem.HostPlayer.len() == 0)
 		{
-			printl("[HOST-DECIDER-LoadAdmins] New host is "+admin)
+			printR("[HOST-DECIDER-LoadAdmins] New host is "+admin)
 			AdminSystem.HostPlayer[admin] <- true;
 			searchForHost = false;
 		}
@@ -1406,7 +1406,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 		if(Utils.GetIDFromArray(::UserLevelNames,level) == -1)
 		{
 			level = "PS_USER_NONE";
-			printl("[USER-LEVEL-ERROR] User level: '"+splt[1]+"' is not recognized for user: "+splt[0])
+			printR("[USER-LEVEL-ERROR] User level: '"+splt[1]+"' is not recognized for user: "+splt[0])
 		}
 		
 		if ( user.find("STEAM_0") != null )
@@ -1417,7 +1417,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 			
 		if(::AdminSystem.HostPlayer.len() == 0 && level == "PS_USER_HOST")
 		{
-			printl("[HOST-DECIDER-LoadUserLevels] New host is "+user)
+			printR("[HOST-DECIDER-LoadUserLevels] New host is "+user)
 			::AdminSystem.HostPlayer[user] <- true
 			currhost = user
 			currhostname = currname
@@ -1633,7 +1633,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 					}
 					else
 					{
-						printl("[Meteor-Shower-Error] Failed to load the meteor_shower_settings.txt, delete the file to fix the issue.");
+						printR("[Meteor-Shower-Error] Failed to load the meteor_shower_settings.txt, delete the file to fix the issue.");
 						AdminSystem._meteor_shower_args <- Constants.GetMeteorShowerSettingsDefaults();
 						return;
 					}
@@ -1718,7 +1718,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
 
 ::AdminSystem.IsPrivileged <- function ( player, silent = false)
 {
-	printl("[DEPRECATION-WARNING] 'AdminSystem.IsPrivileged(player,silent)' function has been deprecated! Use 'player.HasPrivilege(PS_USER_ADMIN)' in your functions!")
+	printR("[DEPRECATION-WARNING] 'AdminSystem.IsPrivileged(player,silent)' function has been deprecated! Use 'player.HasPrivilege(PS_USER_ADMIN)' in your functions!")
 	if ( Director.IsSinglePlayerGame() || player.IsServerHost() )
 		return true;
 	
@@ -1759,7 +1759,7 @@ function Notifications::OnBotReplacedPlayer::RemoveQuixBinds(player,bot,args)
  */
 ::AdminSystem.HasScriptAuth <- function ( player , silent = false)
 {
-	printl("[DEPRECATION-WARNING] 'AdminSystem.HasScriptAuth(player,silent)' function has been deprecated! Use 'player.HasPrivilege(PS_USER_SCRIPTER)' in your functions!")
+	printR("[DEPRECATION-WARNING] 'AdminSystem.HasScriptAuth(player,silent)' function has been deprecated! Use 'player.HasPrivilege(PS_USER_SCRIPTER)' in your functions!")
 	if ( Director.IsSinglePlayerGame() || player.IsServerHost() )
 		return true;
 	
@@ -1845,29 +1845,29 @@ function Notifications::OnRoundStart::RandomSeeding()
 		local t = date()
 		local seed = format("%d%02d%02d%02d%02d",t.month,t.day,t.hour,t.minute,t.second).tointeger();
 		srand(seed)
-		printl("[RANDOM-SEED] Using random seed: "+seed)
+		printR("[RANDOM-SEED] Using random seed: "+seed)
 	}
 	catch(e)
 	{
-		printl("[ERROR-RANDOM-SEED] Failed to set random seed: "+e)
+		printR("[ERROR-RANDOM-SEED] Failed to set random seed: "+e)
 	}
 }
 
 function Notifications::OnRoundStart::ColorfulVehicles()
 {
-	if(::AdminSystem.Vars.ColorfulVehiclesState)
+	if(IsCurrentMapAnOfficialMap() && ::AdminSystem.Vars.ColorfulVehiclesState)
 	{
-		printl("[ColorfulVehicles] Setting random colors to props...")
+		printR("[ColorfulVehicles] Setting random colors to props...")
 		local low = split(::AdminSystem.Vars.ColorfulVehiclesRanges.darkest," ")
 		local high = split(::AdminSystem.Vars.ColorfulVehiclesRanges.brightest," ")
 		if(low.len() != 3)
 		{
-			printl("[COLORFUL_VEHICLES-ERROR] Darkest color range format is wrong!")
+			printR("[COLORFUL_VEHICLES-ERROR] Darkest color range format is wrong!")
 			return
 		}
 		if(high.len() != 3)
 		{
-			printl("[COLORFUL_VEHICLES-ERROR] Brightest color range format is wrong!")
+			printR("[COLORFUL_VEHICLES-ERROR] Brightest color range format is wrong!")
 			return
 		}
 		try
@@ -1877,7 +1877,7 @@ function Notifications::OnRoundStart::ColorfulVehicles()
 		}
 		catch(e)
 		{
-			printl("[COLORFUL_VEHICLES-ERROR] Color range has non-numeric values!")
+			printR("[COLORFUL_VEHICLES-ERROR] Color range has non-numeric values!")
 			return
 		}
 
@@ -2114,73 +2114,73 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 	// Have to do this because squirrel is restoring "coach" as "Coach"
 	if("Coach" in AdminSystem.Vars._outputsEnabled)
 	{
-		//printl("[Custom-Fix] Applying fixes to outputs table...");
+		//printR("[Custom-Fix] Applying fixes to outputs table...");
 		AdminSystem.Vars._outputsEnabled.coach <- AdminSystem.Vars._outputsEnabled.Coach;
 		delete AdminSystem.Vars._outputsEnabled.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._saveLastLine)
 	{
-		//printl("[Custom-Fix] Applying fixes to LastLine table...");
+		//printR("[Custom-Fix] Applying fixes to LastLine table...");
 		AdminSystem.Vars._saveLastLine.coach <- AdminSystem.Vars._saveLastLine.Coach;
 		delete AdminSystem.Vars._saveLastLine.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._savedLine)
 	{
-		//printl("[Custom-Fix] Applying fixes to SavedLine table...");
+		//printR("[Custom-Fix] Applying fixes to SavedLine table...");
 		AdminSystem.Vars._savedLine.coach <- Utils.TableCopy(AdminSystem.Vars._savedLine.Coach);
 		delete AdminSystem.Vars._savedLine.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._saveLastModel)
 	{
-		//printl("[Custom-Fix] Applying fixes to LastModel table...");
+		//printR("[Custom-Fix] Applying fixes to LastModel table...");
 		AdminSystem.Vars._saveLastModel.coach <- AdminSystem.Vars._saveLastModel.Coach;
 		delete AdminSystem.Vars._saveLastModel.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._savedModel)
 	{
-		//printl("[Custom-Fix] Applying fixes to SavedModel table...");
+		//printR("[Custom-Fix] Applying fixes to SavedModel table...");
 		AdminSystem.Vars._savedModel.coach <- Utils.TableCopy(AdminSystem.Vars._savedModel.Coach);
 		delete AdminSystem.Vars._savedModel.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._savedParticle)
 	{
-		//printl("[Custom-Fix] Applying fixes to SavedParticle table...");
+		//printR("[Custom-Fix] Applying fixes to SavedParticle table...");
 		AdminSystem.Vars._savedParticle.coach <- Utils.TableCopy(AdminSystem.Vars._savedParticle.Coach);
 		delete AdminSystem.Vars._savedParticle.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._saveLastParticle)
 	{
-		//printl("[Custom-Fix] Applying fixes to LastParticle table...");
+		//printR("[Custom-Fix] Applying fixes to LastParticle table...");
 		AdminSystem.Vars._saveLastParticle.coach <- AdminSystem.Vars._saveLastParticle.Coach;
 		delete AdminSystem.Vars._saveLastParticle.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._preferred_duration)
 	{
-		//printl("[Custom-Fix] Applying fixes to preferred_duration table...");
+		//printR("[Custom-Fix] Applying fixes to preferred_duration table...");
 		AdminSystem.Vars._preferred_duration.coach <- AdminSystem.Vars._preferred_duration.Coach;
 		delete AdminSystem.Vars._preferred_duration.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._prop_spawn_settings_menu_type)
 	{
-		//printl("[Custom-Fix] Applying fixes to prop_spawn_settings_menu_type table...");
+		//printR("[Custom-Fix] Applying fixes to prop_spawn_settings_menu_type table...");
 		AdminSystem.Vars._prop_spawn_settings_menu_type.coach <- AdminSystem.Vars._prop_spawn_settings_menu_type.Coach;
 		delete AdminSystem.Vars._prop_spawn_settings_menu_type.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._prop_spawn_settings)
 	{
-		//printl("[Custom-Fix] Applying fixes to prop_spawn_settings table...");
+		//printR("[Custom-Fix] Applying fixes to prop_spawn_settings table...");
 		AdminSystem.Vars._prop_spawn_settings.coach <- Utils.TableCopy(AdminSystem.Vars._prop_spawn_settings.Coach);
 		delete AdminSystem.Vars._prop_spawn_settings.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._explosion_settings)
 	{
-		//printl("[Custom-Fix] Applying fixes to explosion_settings table...");
+		//printR("[Custom-Fix] Applying fixes to explosion_settings table...");
 		AdminSystem.Vars._explosion_settings.coach <- Utils.TableCopy(AdminSystem.Vars._explosion_settings.Coach);
 		delete AdminSystem.Vars._explosion_settings.Coach;
 	}
 	if("Coach" in AdminSystem.Vars._heldEntity)
 	{
-		//printl("[Custom-Fix] Applying fixes to HeldEntity table...");
+		//printR("[Custom-Fix] Applying fixes to HeldEntity table...");
 		AdminSystem.Vars._heldEntity.coach <- Utils.TableCopy(AdminSystem.Vars._heldEntity.Coach);
 		delete AdminSystem.Vars._heldEntity.Coach;
 		AdminSystem.Vars._heldEntity.bill.entid = "";
@@ -2194,7 +2194,7 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 	}
 	if("Coach" in AdminSystem.Vars._wornHat)
 	{
-		//printl("[Custom-Fix] Applying fixes to WornHat table...");
+		//printR("[Custom-Fix] Applying fixes to WornHat table...");
 		AdminSystem.Vars._wornHat.coach <- Utils.TableCopy(AdminSystem.Vars._wornHat.Coach);
 		delete AdminSystem.Vars._wornHat.Coach;
 		AdminSystem.Vars._wornHat.bill.entid = "";
@@ -2208,14 +2208,14 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 	}
 	if("Coach" in AdminSystem.Vars._modelPreference)
 	{
-		//printl("[Custom-Fix] Applying fixes to model preference table...");
+		//printR("[Custom-Fix] Applying fixes to model preference table...");
 		AdminSystem.Vars._modelPreference.coach <- Utils.TableCopy(AdminSystem.Vars._modelPreference.Coach);
 		delete AdminSystem.Vars._modelPreference.Coach;
 	}
 	local skip = false;
 	if("Coach" in AdminSystem.Vars._CustomResponseOptions)
 	{	
-		//printl("[Custom-Fix] Applying fixes to CustomResponse table...");
+		//printR("[Custom-Fix] Applying fixes to CustomResponse table...");
 		AdminSystem.Vars._CustomResponseOptions.coach <- Utils.TableCopy(AdminSystem.Vars._CustomResponseOptions.Coach);
 		delete AdminSystem.Vars._CustomResponseOptions.Coach;
 		AdminSystem.Vars._CustomResponse.coach <- Utils.TableCopy(AdminSystem.Vars._CustomResponse.Coach);
@@ -2226,7 +2226,7 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 		// Apply options created by admins
 		AdminSystem.LoadCustomSequences();
 		//throw("No need for fixes in CustomRespose tables");
-		//printl("[OnRoundStart-Info] No need for fixes in CustomRespose tables");
+		//printR("[OnRoundStart-Info] No need for fixes in CustomRespose tables");
 		skip = true;
 	}
 
@@ -2518,9 +2518,9 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 	}
 		
 	//}
-	//catch(e){printl("[OnRoundStart-AdminLoadFiles] "+e);}
+	//catch(e){printR("[OnRoundStart-AdminLoadFiles] "+e);}
 	
-	printl("[Custom] Loaded custom responses created by admins");
+	printR("[Custom] Loaded custom responses created by admins");
 	
 	if(AdminSystem.Vars._ghost_zombies_state == 1)
 	{
@@ -2546,7 +2546,7 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 	}
 	else
 	{
-		printl("[Bot-Thinker] Disabled looting/sharing thinking for bots ");
+		printR("[Bot-Thinker] Disabled looting/sharing thinking for bots ");
 	}
 
 	//Restore models if necessary
@@ -2561,11 +2561,11 @@ function Notifications::OnRoundStart::AdminLoadFiles()
 	local found = Objects.AnyOfName("think_adder_base_entity")
 	if(found != null)
 	{
-		printl("[Bot-Thinker] Bot looting/sharing thinking already enabled via adder #"+found.GetIndex());
+		printR("[Bot-Thinker] Bot looting/sharing thinking already enabled via adder #"+found.GetIndex());
 		return;
 	}
 	local tadd = _CreateLootThinker();
-	printl("[Bot-Thinker] Enabled looting/sharing thinking for bots via adder #"+tadd.GetIndex());
+	printR("[Bot-Thinker] Enabled looting/sharing thinking for bots via adder #"+tadd.GetIndex());
 }
 
 ::AdminSystem.RestoreModels <- function(player)
@@ -2687,7 +2687,7 @@ function Notifications::OnPlayerJoined::UserLevelCheck( player, name, IPAddress,
 					local _name = strip(row.slice(index + 2))
 					if(i == 0 && AdminSystem.HostPlayer.len() == 0)
 					{
-						printl("[HOST-DECIDER-OnPlayerJoined] New host is "+_steamid)
+						printR("[HOST-DECIDER-OnPlayerJoined] New host is "+_steamid)
 						tbl[_steamid] <- [PS_USER_HOST,_name];
 						::AdminSystem.HostPlayer[_steamid] <- true
 						foundHost = true
@@ -2723,7 +2723,7 @@ function Notifications::OnPlayerJoined::UserLevelCheck( player, name, IPAddress,
 		
 		if(!foundHost)
 		{
-			printl("[HOST-DECIDER-OnPlayerJoined] New host is "+steamid)
+			printR("[HOST-DECIDER-OnPlayerJoined] New host is "+steamid)
 			::AdminSystem.HostPlayer[steamid] <- true
 		}
 
@@ -6701,7 +6701,7 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	
 	if(fileContents == null)
 	{
-		printl("[Bot-Params] Creating bot share/loot settings file for the first time...");
+		printR("[Bot-Params] Creating bot share/loot settings file for the first time...");
 		StringToFile(::Constants.Directories.BotSettings,::Constants.GetBotShareLootSettings());
 		fileContents = FileToString(::Constants.Directories.BotSettings);
 	}
@@ -7688,7 +7688,7 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	local filelist = FileToString(Constants.Directories.CustomVehicle);	// List of files
 	if(filelist == null)
 	{
-		printl("[Custom-Vehicle] Creating "+Constants.Directories.CustomVehicle+" for the first time...")
+		printR("[Custom-Vehicle] Creating "+Constants.Directories.CustomVehicle+" for the first time...")
 		StringToFile(Constants.Directories.CustomVehicle,strip(Constants.CustomVehicleListDefaults));
 		filelist = FileToString(Constants.Directories.CustomVehicle);
 	}
@@ -7696,7 +7696,7 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	local example = FileToString(Constants.Directories.CustomVehicleExample);	// Example v150
 	if(example == null)
 	{
-		printl("[Vehicle-Examples] Creating v1.6.0 examples in "+Constants.Directories.CustomVehicleExample+" for the first time...")
+		printR("[Vehicle-Examples] Creating v1.6.0 examples in "+Constants.Directories.CustomVehicleExample+" for the first time...")
 		StringToFile(Constants.Directories.CustomVehicleExample,strip(Constants.CustomVehicleDefaults.v1_6_0));
 		example = FileToString(Constants.Directories.CustomVehicleExample);
 	}
@@ -7709,7 +7709,7 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	// 	local ex = FileToString(pth);
 	// 	if(ex == null)
 	// 	{
-	// 		printl("[Binds-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
+	// 		printR("[Binds-Examples] Creating "+count+" new examples from version "+vers+" in "+pth+" for the first time...")
 	// 		StringToFile(pth,Constants.CustomBindsTableDefaults[cleanvers]);
 	// 		ex = FileToString(pth);
 	// 	}
@@ -17483,7 +17483,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 				}
 				catch(e)
 				{
-					printl("[Defaults-Error] Formatting of spawn_angles.val in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
+					printR("[Defaults-Error] Formatting of spawn_angles.val in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
 				}
 				break;
 			}
@@ -17495,20 +17495,20 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 				}
 				catch(e)
 				{
-					printl("[Defaults-Error] Formatting of spawn_angles.val in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
+					printR("[Defaults-Error] Formatting of spawn_angles.val in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
 				}
 				break;
 			}
 			default:
 			{
-				printl("[Defaults-Error] Formatting of spawn_angles.val in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
+				printR("[Defaults-Error] Formatting of spawn_angles.val in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
 				break;
 			}
 		}
 	}
 	else if(typeof tbl.val != "QAngle")
 	{
-		printl("[Defaults-Error] Formatting of spawn_angles in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
+		printR("[Defaults-Error] Formatting of spawn_angles in Tables.PropSpawn is wrong, using QAngle(0,0,0) instead...")
 	}
 	else
 	{
@@ -22774,7 +22774,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 		point_clientcommand.Input("Kill","",delay.tofloat()+0.5);	// Kill it afterwards
 
 	if(report2host && !target_is_host)
-		printl("[Client-broadcast]Executing client command on "+client_character+"->"+command);	
+		printR("[Client-broadcast]Executing client command on "+client_character+"->"+command);	
 }
 
 /*
@@ -22806,7 +22806,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 		AdminSystem._Clientbroadcast(character,"echo ....^^^^^^^^^^^^^^^^^^^^...COMMAND OUTPUT ABOVE...^^^^^^^^^^^^^^^^^^^^....",1,!reporttohost,delay_end_msg);
 
 	if(reporttohost && msgtype!="debug" && !(Utils.GetPlayerFromName(character).GetSteamID() in ::AdminSystem.HostPlayer))
-		printl("[Broadcast] Printed to "+character+" ("+msgtype+"):"+message);
+		printR("[Broadcast] Printed to "+character+" ("+msgtype+"):"+message);
 }
 
 /*

--- a/2229460523/scripts/vscripts/admin_system.nut
+++ b/2229460523/scripts/vscripts/admin_system.nut
@@ -1,5 +1,6 @@
 //-----------------------------------------------------
-printl("Activating Admin System - project_smok");
+Msg("Activating Admin System - ");
+error("project_smok\n")
 
 /**
  * Admin System by Rayman1103
@@ -51,9 +52,15 @@ IncludeScript("Project_smok/QuickTimers");
 // Include the vehicle scripts
 IncludeScript("Project_smok/Vehicles");
 
-printl("|-------------------------------------------|")
-printl(format("| project_smok %s , Date: %s",::Constants.Version.Number,::Constants.Version.Date))
-printl("|-------------------------------------------|")
+error("|")
+Msg("-----------------------------------------------")
+error("|\n|")
+Msg(" project_smok ")
+error(::Constants.Version.Number)
+Msg(" , Version Date ")
+error(format("%s |\n|",::Constants.Version.Date))
+Msg("-----------------------------------------------")
+error("|\n")
 
 // Messages
 ::CmdMessages <- ::Messages.BIM.CMD;
@@ -1846,6 +1853,131 @@ function Notifications::OnRoundStart::RandomSeeding()
 	}
 }
 
+function Notifications::OnRoundStart::ColorfulVehicles()
+{
+	if(::AdminSystem.Vars.ColorfulVehiclesState)
+	{
+		printl("[ColorfulVehicles] Setting random colors to props...")
+		local low = split(::AdminSystem.Vars.ColorfulVehiclesRanges.darkest," ")
+		local high = split(::AdminSystem.Vars.ColorfulVehiclesRanges.brightest," ")
+		if(low.len() != 3)
+		{
+			printl("[COLORFUL_VEHICLES-ERROR] Darkest color range format is wrong!")
+			return
+		}
+		if(high.len() != 3)
+		{
+			printl("[COLORFUL_VEHICLES-ERROR] Brightest color range format is wrong!")
+			return
+		}
+		try
+		{
+			low = low.map(@(x) x.tointeger())
+			high = high.map(@(x) x.tointeger())
+		}
+		catch(e)
+		{
+			printl("[COLORFUL_VEHICLES-ERROR] Color range has non-numeric values!")
+			return
+		}
+
+		local valid_vehicle_classes =
+		{
+			prop_dynamic = true
+			prop_dynamic_override = true
+			prop_car_alarm = true
+			prop_vehicle = true
+			prop_physics_override = true
+			prop_physics = true
+		}
+
+		local valid_vehicle_models =
+		{
+			"models/props_vehicles/cara_69sedan.mdl" : true
+			"models/props_vehicles/cara_84sedan.mdl" : true
+			"models/props_vehicles/cara_95sedan.mdl" : true
+			"models/props_vehicles/cara_82hatchback.mdl" : true
+			"models/props_vehicles/sailboat.mdl" : true
+			"models/lostcoast/props_wasteland/boat_fishing01a.mdl" : true
+			"models/props_vehicles/boat_fishing02_static.mdl" : true
+			"models/lostcoast/props_wasteland/boat_drydock01a.mdl" : true
+			"models/props_urban/boat001.mdl" : true
+			"models/props_urban/boat002.mdl" : true
+			"models/props_vehicles/boat_ski.mdl" : true
+			"models/props_vehicles/boat_smash.mdl" : true
+			"models/lostcoast/props_wasteland/boat_wooden01a.mdl" : true
+			"models/lostcoast/props_wasteland/boat_wooden02a.mdl" : true
+			"models/lostcoast/props_wasteland/boat_wooden03a.mdl" : true
+			"models/props_canal/boat001a.mdl" : true
+			"models/props_vehicles/train_enginecar.mdl" : true
+			"models/props_vehicles/train_engine_military.mdl" : true
+			"models/props_vehicles/train_box.mdl" : true
+			"models/props_vehicles/train_box_open.mdl" : true
+			"models/props_vehicles/train_box_small.mdl" : true
+			"models/props_vehicles/train_boxwreck.mdl" : true
+			"models/props_vehicles/boxcar_tanktrap_exterior.mdl" : true
+			"models/props_vehicles/boxcar_tanktrap_interior.mdl" : true
+			"models/props_vehicles/boxcar_tanktrap_door.mdl" : true
+			"models/props_vehicles/train_orecar.mdl" : true
+			"models/props_vehicles/train_flatcar.mdl" : true
+			"models/props_vehicles/train_flatcar_small.mdl" : true
+			"models/props_vehicles/train_tank.mdl" : true
+			"models/props_vehicles/train_tank_small.mdl" : true
+			"models/props_trainstation/train_transporter.mdl" : true
+			"models/props_unique/subwaycar_all_onetexture.mdl" : true
+			"models/props_vehicles/cara_95sedan_wrecked.mdl" : true
+			"models/props_vehicles/cara_82hatchback_wrecked.mdl" : true
+			"models/props_vehicles/news_van.mdl" : true
+			"models/props_vehicles/van_cab_controls.mdl" : true
+			"models/props_vehicles/longnose_truck.mdl" : true
+			"models/props_vehicles/flatnose_truck.mdl" : true
+			"models/props_vehicles/semi_truck3.mdl" : true
+			"models/props_vehicles/pickup_truck_78.mdl" : true
+			"models/props_vehicles/pickup_truck_2004.mdl" : true
+			"models/props_vehicles/police_car_rural.mdl" : true
+			"models/props_vehicles/suv_2001.mdl" : true
+			"models/props_vehicles/taxi_cab.mdl" : true
+			"models/props_vehicles/police_car_city.mdl" : true
+			"models/props_vehicles/front_loader01_rear.mdl" : true
+			"models/props_vehicles/front_loader01_front_down.mdl" : true
+			"models/props_vehicles/van.mdl" : true
+			"models/props_vehicles/van_cab_controls.mdl" : true
+			"models/props_vehicles/boat_cabin35ft.mdl" : true
+			"models/props_vehicles/boat_trailer35ft.mdl" : true
+			"models/props_vehicles/utility_truck.mdl" : true
+			"models/props_vehicles/utility_truck_windows.mdl" : true
+			"models/props/de_nuke/truck_nuke.mdl" : true
+			"models/props_vehicles/radio_generator.mdl" : true
+			"models/props_vehicles/generatortrailer01.mdl" : true
+			"models/props_vehicles/m119howitzer_01.mdl" : true
+			"models/props_vehicles/deliveryvan_armored.mdl" : true
+			"models/props_vehicles/floodlight_generator_nolight.mdl" : true
+			"models/props_vehicles/airport_baggage_tractor.mdl" : true
+			"models/props_vehicles/airport_baggage_cart2.mdl" : true
+			"models/props_vehicles/airliner_finale_left.mdl" : true
+			"models/props_vehicles/airliner_finale_right.mdl" : true
+			"models/props_fairgrounds/bumpercar.mdl" : true
+			"models/props_fairgrounds/coaster_car01.mdl" : true
+			"models/props_waterfront/tour_bus.mdl" : true
+			"models/props_vehicles/helicopter_rescue.mdl" : true
+			"models/props_vehicles/racecar_damaged.mdl" : true
+			"models/props_vehicles/bus01.mdl" : true
+			"models/props_vehicles/bus01_2.mdl" : true
+			"models/props_vehicles/church_bus01.mdl" : true
+			"models/props_vehicles/c130.mdl" : true
+		}
+
+		foreach(classname,st in valid_vehicle_classes)
+		{
+			foreach(ent in Objects.OfClassname(classname))
+			{
+				if(ent.GetModel() in valid_vehicle_models)
+					ent.SetColor(RandomInt(low[0],high[0]).tostring(),RandomInt(low[1],high[1]).tostring(),RandomInt(low[2],high[2]).tostring(),"255");
+			}
+		}
+	}
+}
+
 function Notifications::OnRoundStart::AdminLoadFiles()
 {
 	// Deprecated
@@ -2855,11 +2987,14 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 		{
 			local tname = strip(Command.slice(Command.find(">") + 1))
 			if(tname == "self" || tname == "!self")
-				target = player
-			else if(tname != "" && ((target = Entity(tname)).IsEntityValid() || (target = Utils.GetPlayerFromName(tname) != null)))
+				target = Utils.GetEntityOrPlayer(player.GetBaseEntity());
+			else if(tname != "" && ((target = Entity(tname)).IsEntityValid() || ((target = Utils.GetPlayerFromName(tname)) != null)))
 				Command = Command.slice(0, Command.find(">"))
 			else
 				target = null
+				
+			if(target)
+				target = Utils.GetEntityOrPlayer(target.GetBaseEntity())
 		}
 		cleanBaseCmd = Command in ::ChatTriggers
 							? Command
@@ -2951,7 +3086,7 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	}
 
 	if(target)
-		player.GetScriptScope().PS_ONETIME_TARGET <- target;
+		player.GetScriptScope().PS_ONETIME_TARGET <- Utils.GetEntityOrPlayer(target);
 
 	switch ( cleanBaseCmd )
 	{
@@ -4896,12 +5031,11 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 
 				if(target.GetNetProp("m_hTarget") != null && Entity(target.GetNetProp("m_hTarget")).GetEntityHandle() == parent.GetEntityHandle())
 				{
-					DoEntFire("!self","setparent","#"+parent.GetIndex(),0,null,target.GetBaseEntity());
 					if(value2 == "")
-					{
 						value2 = "forward"
-					}
-                    DoEntFire("!self","setparentattachmentmaintainoffset",value2,0.05,null,target.GetBaseEntity());
+
+					target.SetNetProp("m_pParent",parent.GetBaseEntity())
+					DoEntFire("!self", "setparentattachmentmaintainoffset", value2, 0, null, target.GetBaseEntity());
 					break;
 				}
 
@@ -4938,10 +5072,12 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 					Messages.ThrowPlayer(player,"Camera(#"+target.GetIndex()+") is already attached(to #"+target.GetParent().GetIndex()+")")
 					return
 				}
-				DoEntFire("!self","setparent","#"+parent.GetIndex(),0,null,target.GetBaseEntity());
-				if(value2 != "")
+				if(value2 == "")
+					DoEntFire("!self","setparent","#"+parent.GetIndex(),0,null,target.GetBaseEntity());
+				else
 				{
-					DoEntFire("!self","setparentattachmentmaintainoffset",value2,0.05,null,target.GetBaseEntity());
+					target.SetNetProp("m_pParent",parent.GetBaseEntity())
+					DoEntFire("!self", "setparentattachmentmaintainoffset", value2, 0, null, target.GetBaseEntity());
 				}
 			}
 			break;
@@ -5923,15 +6059,9 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 		if(entclass == "player")
 			continue;
 
-		if(entmdl.find("*") != null)
-			continue;
+		if(ent.HasBadPhysicsModel())
+			continue
 		
-		if((entmdl.find("hybridphysx") != null)) // Animation props etc ignored
-			continue;
-
-		if((entmdl.find("skybox") != null)) // Skybox stuff
-			continue;
-
 		if(SessionState.MapName in ::GivePhysicsMapSpecificBans)
 		{ 
 		  if((ent.GetName() in ::GivePhysicsMapSpecificBans[SessionState.MapName].entities
@@ -6045,16 +6175,10 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 		}
 		else if(!AdminSystem.Vars._grabAvailable[entclass])
 			return
-			
-		if(looked.GetModel().find("*") != null)
-			return;
-
-		if((looked.GetModel().find("hybridphysx") != null)) // Animation props etc ignored
-			return;
-
-		if((looked.GetModel().find("skybox") != null)) // Skybox stuff
-			return;
-			
+		
+		if(looked.HasBadPhysicsModel())
+			return
+		
 		::GivePhysicsToEntity(looked)
 	}
 	else if(rad == "all")
@@ -6088,15 +6212,9 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 			if(entclass == "player")
 				continue;
 			
-			if(entmdl.find("*") != null)
-				continue;
+			if(ent.HasBadPhysicsModel())
+				continue
 			
-			if((entmdl.find("hybridphysx") != null)) // Animation props etc ignored
-				continue;
-
-			if((entmdl.find("skybox") != null)) // Skybox stuff
-				continue;
-				
 			if(SessionState.MapName in ::GivePhysicsMapSpecificBans)
 			{ 
 				if((ent.GetName() in ::GivePhysicsMapSpecificBans[SessionState.MapName].entities
@@ -6200,17 +6318,10 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 			else if(!AdminSystem.Vars._grabAvailable[entclass])
 				continue
 			
-			local entmdl = ent.GetModel()
-			if(entmdl.find("*") != null)
-				continue;
-			
-			if((entmdl.find("hybridphysx") != null)) // Animation props etc ignored
-				continue;
-			
-			if((entmdl.find("skybox") != null)) // Skybox stuff
-				continue;
+			if(ent.HasBadPhysicsModel())
+				continue
 
-			if(!::CheckPhysicsAvailabilityForModel(entmdl,ent,GivePhysicsToEntity))
+			if(!::CheckPhysicsAvailabilityForModel(ent.GetModel(),ent,GivePhysicsToEntity))
 				continue
 
 			::GivePhysicsToEntity(ent)	
@@ -6336,20 +6447,11 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	}
 }
 
-::AdminSystem.GoRagdollCmd <- function(player,args)
+::StartRagdolling <- function(args)
 {
-	if(::VSLib.EasyLogic.NextMapContinues)
-		return;
-
-	local rag = Objects.AnyOfName(Constants.Targetnames.Ragdoll+player.GetIndex())
-	if(rag != null && rag.IsEntityValid())
-		return;
-	
-	if(RagdollStateCheck(player))
-		return;
+	local rag, player = args.player
 	
 	local idx = player.GetIndex();
-
 
 	local ang = QAngle(0,player.GetEyeAngles().Yaw(),0);
 	local org = player.GetOrigin();
@@ -6361,7 +6463,7 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
     local is_ragdoll_mdl = RagdollOrPhysicsDecider(player.GetModel()) == "prop_ragdoll"
 	if(is_ragdoll_mdl)
 	{
-		rag = Utils.SpawnRagdoll(mdl,org,ang,{spawnflags=32772}); // TO-DO: Find a way to do this without a secondary ragdoll
+		rag = Utils.SpawnRagdoll(mdl,org,ang,{spawnflags=32772});
 		rag.SetRenderMode(RENDER_NONE);
 	}
 	else
@@ -6395,11 +6497,10 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 
 	if(is_ragdoll_mdl)
 	{
-	    player.Input("setparent","#"+rag.GetIndex(),0.08)
+	    player.Input("setparent","#"+rag.GetIndex() + ",bleedout",0.09)
 		rag.GetScriptScope()["PS_OWNER_ORIGIN"] <- Vector(0,0,0)
 
 		player.SetRenderEffects(RENDERFX_RAGDOLL);
-	    player.Input("setparentattachment","bleedout",0.11)
 		rag.SetNetProp("m_CollisionGroup",2)
 		if(RagParams.useseq)
 		{
@@ -6469,14 +6570,41 @@ function EasyLogic::OnUserCommand::AdminCommands(player, args, text)
 	::RagdollControls.Initialize(player,rag,is_ragdoll_mdl);
 }
 
+::AdminSystem.GoRagdollCmd <- function(player,args)
+{
+	if(::VSLib.EasyLogic.NextMapContinues)
+		return;
+
+	if(RagdollStateCheck(player))
+		return;
+
+	if("PS_RAGDOLL_PROCESSING_STATE" in player.GetScriptScope() 
+		&& player.GetScriptScope()["PS_RAGDOLL_PROCESSING_STATE"])
+		return
+
+    player.GetScriptScope()["PS_RAGDOLL_PROCESSING_STATE"] <- true
+
+	local rag = Objects.AnyOfName(Constants.Targetnames.Ragdoll+player.GetIndex())
+	if(rag != null && rag.IsEntityValid())
+		RecoverRagdollInitial(rag);
+	else
+		::StartRagdolling({player=player})
+    
+    // Prevent spam
+    player.Input("runscriptcode","self.GetScriptScope().PS_RAGDOLL_PROCESSING_STATE <- false",0.2)
+}
+
 ::AdminSystem.RecoverRagdollCmd <- function(player,args)
 {
-		
 	local rag = player.GetRagdollEntity()
 
 	if(rag == null)
 		return;
 	
+	if("PS_RAGDOLL_PROCESSING_STATE" in player.GetScriptScope() 
+		&& player.GetScriptScope()["PS_RAGDOLL_PROCESSING_STATE"])
+		return
+
 	RecoverRagdollInitial(rag);
 }
 
@@ -8670,6 +8798,7 @@ enum __
 {
 	local argtable = AdminSystem._meteor_shower_args;
 	local meteor = Ent("#"+met)
+	meteor.SetVelocity(Vector(0,0,0))
 
 	local prtc = null
 	local explosion = null
@@ -12240,7 +12369,7 @@ function ChatTriggers::out( player, args, text )
 	if(args.len() == 0)
 		return;
 
-	local res = compilestring("local __tempvar__="+text.slice(5)+";return __tempvar__;")();
+	local res = compilestring("local __tempvar__="+Utils.CombineArray(args," ")+";return __tempvar__;")();
 	::AdminSystem.out(res,player);
 }
 
@@ -22722,43 +22851,56 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 	}
 
 	// Line source is random
-	if(linesource == "random")
+	if(linesource == "!random" || linesource == "random")
 	{
 		linesource = Utils.GetRandValueFromArray(AdminSystem.Vars.CharacterNamesLower);
 		while(linesource == "" || linesource == "survivor")
 			linesource = Utils.GetRandValueFromArray(AdminSystem.Vars.CharacterNamesLower);
 	}
+	else if(linesource == "self" || linesource == "!self")
+		linesource = null
 
 	// Speaker selection
-	if(targetname == "random")
-	{	
-		targetname = Utils.GetRandValueFromArray(Players.AliveSurvivors()).GetCharacterNameLower();
-		speaker = Utils.GetPlayerFromName(targetname);
-	}
-	else if(targetname == "self")
+	switch(targetname)
 	{
-		targetname = name;
-		speaker = player;
-	}
-	else if(targetname == "picker")
-	{
-		targetname = player.GetLookingEntity(GRAB_YEET_TRACE_MASK);
+		case "!random":
+		case "random":
+		{	
+			targetname = Utils.GetRandValueFromArray(Players.AliveSurvivors()).GetCharacterNameLower();
+			speaker = Utils.GetPlayerFromName(targetname);
+			break;
+		}
+		case "!self":
+		case "self":
+		{
+			targetname = name;
+			speaker = player;
+			break;
+		}
+		case "!picker":
+		case "picker":
+		{
+			targetname = player.GetLookingEntity(GRAB_YEET_TRACE_MASK);
 
-		if(targetname == null){return;}
-		if(targetname.GetClassname() != "player"){return;}
-	
-		targetname = targetname.GetCharacterNameLower();
-		speaker = Utils.GetPlayerFromName(targetname);
-	}
-	else if(Utils.GetIDFromArray(AdminSystem.Vars.CharacterNamesLower,targetname) == -1)
-	{
-		Messages.ThrowPlayer(player,Messages.BIM.NotACharacter(GetArgument(1)));
-		::SpellChecker.Levenshtein(3,3,"character name").PrintBestMatches(player.GetBaseEntity(),GetArgument(1),Utils.ArrayToTable(AdminSystem.Vars.CharacterNamesLower.slice(0,8)))
-		return;
-	}
-	else
-	{
-		speaker = Player("!"+targetname);
+			if(targetname == null){return;}
+			if(targetname.GetClassname() != "player"){return;}
+		
+			targetname = targetname.GetCharacterNameLower();
+			speaker = Utils.GetPlayerFromName(targetname);
+			break;
+		}
+		default:
+		{
+			if(Utils.GetIDFromArray(AdminSystem.Vars.CharacterNamesLower,targetname) == -1)
+			{
+				Messages.ThrowPlayer(player,Messages.BIM.NotACharacter(GetArgument(1)));
+				::SpellChecker.Levenshtein(3,3,"character name").PrintBestMatches(player.GetBaseEntity(),GetArgument(1),Utils.ArrayToTable(AdminSystem.Vars.CharacterNamesLower.slice(0,8)))
+				return;
+			}
+			else
+				speaker = Player("!"+targetname);
+			break;
+		}
 	}
 
 	if(speaker==null)
@@ -23261,7 +23403,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 
 	local entclass = ent.GetClassname();
 
-	if(entclass == "player")
+	if(entclass == "player" || entclass == "witch")
 		return;
 	// Not in table, in the table but disabled
 	if(!(entclass in AdminSystem.Vars._grabAvailable))
@@ -23273,14 +23415,8 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 	else if(!AdminSystem.Vars._grabAvailable[entclass])
 		return
 
-	if(ent.GetModel().find("*") != null)
-		return;
-
-	if((ent.GetModel().find("hybridphysx") != null))
-		return;
-
-	if((ent.GetModel().find("skybox") != null)) // Skybox stuff
-		return;
+	if(ent.HasBadPhysicsModel())
+		return
 
 	local ind = ent.GetIndex();
 
@@ -23306,10 +23442,10 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 	//ent.SetForwardVector(player.GetForwardVector());
 	
 	ent.SetNetProp("m_CollisionGroup",1);
-	ent.Input("setparent","#"+player.GetIndex(),0);
+	ent.SetNetProp("m_pParent",player.GetBaseEntity())	// Hack
+	DoEntFire("!self", "setparentattachmentmaintainoffset", pos, 0, null, ent.GetBaseEntity());
 	ent.SetOrigin(player.GetEyePosition()+vec+survivorfw);
 	ent.SetAngles(RotateOrientation(player.GetEyeAngles(),QAngle(HatParameters.pitch,HatParameters.yaw,HatParameters.roll)))	
-	ent.Input("setparentattachmentmaintainoffset",pos,0.1);
 }
 
 ::HatParameters <- 
@@ -23422,15 +23558,9 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 				}
 				else if(!AdminSystem.Vars._grabAvailable[entclass])
 					continue
-					
-				if(entmodel.find("*") != null)
-					continue;
-
-				if((entmodel.find("hybridphysx") != null)) // Animation props etc ignored
-					continue;
 				
-				if((entmodel.find("skybox") != null)) // Skybox stuff
-					continue;
+				if(obj.HasBadPhysicsModel())
+					continue
 
 				entind = obj.GetIndex().tostring();
 
@@ -23512,15 +23642,9 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 		}
 		else if(!AdminSystem.Vars._grabAvailable[entclass])
 			return
-			
-		if(ent.GetModel().find("*") != null)
-			return;
 		
-		if((ent.GetModel().find("hybridphysx") != null))
-			return;
-
-		if((ent.GetModel().find("skybox") != null)) // Skybox stuff
-			return;
+		if(ent.HasBadPhysicsModel())
+			return	
 
 		entind = ent.GetIndex().tostring();
 	}
@@ -23562,10 +23686,10 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 			ent.SetOrigin(Vector(entpos.x+fwvec.x,entpos.y+fwvec.y,entpos.z+fwvec.z));
 
 		}
-
-		player.AttachOther(ent,false,0,null);
-		player.SetAttachmentPoint(ent,tbl_heldEnt.grabAttachPos,true,0.035);
-		
+        
+        // Hack: Helps getting rid of delay
+        ent.SetNetProp("m_pParent",player.GetBaseEntity())
+		DoEntFire("!self", "setparentattachmentmaintainoffset", tbl_heldEnt.grabAttachPos, 0, null, ent.GetBaseEntity());
 		AdminSystem.Vars._heldEntity[player.GetCharacterNameLower()].entid = entind;
 	}
 	
@@ -23664,7 +23788,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 	if(entclass == "player")
 	{
 		ent.SetMoveType(MOVETYPE_WALK);
-		ent.Input("RunScriptCode",func+"(Entity("+ent.GetIndex()+")"+extra_arg+")",0);
+		ent.Input("RunScriptCode",func+"(Entity("+ent.GetIndex()+")"+extra_arg+")",0.033);
 	}
 	else if(entclass.find("weapon_") != null) // a weapon spawner or a weapon
 	{
@@ -23674,7 +23798,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 			{
 				ent.SetSpawnFlags(ent.GetSpawnFlags()-1);
 			}
-			ent.Input("RunScriptCode",func+"(Entity("+ent.GetIndex()+")"+extra_arg+")",0);
+			ent.Input("RunScriptCode",func+"(Entity("+ent.GetIndex()+")"+extra_arg+")",0.033);
 		}
 	}
 	else if(entclass.find("physics") != null || entclass in ::_LetGoDropYeetSpecialClasses) // physics entity
@@ -23695,7 +23819,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 			ent.Input("EnableMotion","",0);
 			ent.SetEffects(effects);
 		}
-		ent.Input("RunScriptCode",func+"(Entity("+ent.GetIndex()+")"+extra_arg+")",0);
+		ent.Input("RunScriptCode",func+"(Entity("+ent.GetIndex()+")"+extra_arg+")",0.033);
 	}
 	else // non physics, try creating entity with its model
 	{
@@ -23719,7 +23843,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 			local color = ent.GetNetProp("m_clrRender");
 			local scale = ent.GetModelScale();
 			RecreateHierarchy(ent,new_ent,{color=color,skin=skin,scale=scale,name=ent.GetName()});
-			new_ent.Input("RunScriptCode",func+"(Entity("+new_ent.GetIndex()+")"+extra_arg+")",0);
+			new_ent.Input("RunScriptCode",func+"(Entity("+new_ent.GetIndex()+")"+extra_arg+")",0.033);
 		}
 		else
 		{
@@ -23752,7 +23876,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 								local color = ent.GetNetProp("m_clrRender");
 								local scale = ent.GetModelScale();
 								RecreateHierarchy(ent,new_ent,{color=color,skin=skin,scale=scale,name=ent.GetName()});
-								new_ent.Input("RunScriptCode",func+"(Entity("+new_ent.GetIndex()+")"+extra_arg+")",0);
+								new_ent.Input("RunScriptCode",func+"(Entity("+new_ent.GetIndex()+")"+extra_arg+")",0.033);
 								Printer(Player("!"+name),CmdMessages.Prop.Success("physicsM",new_ent));
 								ent.Kill()
 							}
@@ -23889,7 +24013,14 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 
 ::_dropit <- function(ent)
 {
-	local movetype = ent.GetClassname() == "player" ? MOVETYPE_WALK : MOVETYPE_VPHYSICS
+	local movetype;
+	switch(ent.GetClassname()) 
+	{
+		case "player": movetype = MOVETYPE_WALK; break;
+		case "witch": movetype = MOVETYPE_ZOMBIE_DEFAULT; break;
+		default: movetype = MOVETYPE_VPHYSICS; break;
+	} 
+
 	local a=ent.GetOrigin();
 	if(ent.GetBaseEntity() != null && "ResetSequence" in ent.GetBaseEntity())
 	{
@@ -24494,15 +24625,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 	if(entcls.find("_spawn") != null)
 		return false
 		
-	local entmdl = ent.GetModel().tolower();
-
-	if(entmdl.find("*") != null)
-		return false
-
-	if(entmdl.find("hybridphysx") != null)
-		return false
-
-	if((entmdl.find("skybox") != null)) // Skybox stuff
+	if(ent.HasBadPhysicsModel())
 		return false
 
 	if(SessionState.MapName in ::ZeroGMapSpecificBans
@@ -24514,7 +24637,7 @@ foreach(cmdname,cmdtrigger in ::ChatTriggers)
 			)
 			||
 			(
-				entmdl in ::ZeroGMapSpecificBans[SessionState.MapName].models 
+				ent.GetModel().tolower() in ::ZeroGMapSpecificBans[SessionState.MapName].models 
 			)
 		  )
 		)

--- a/2229460523/scripts/vscripts/admin_system/vslib.nut
+++ b/2229460523/scripts/vscripts/admin_system/vslib.nut
@@ -48,4 +48,4 @@ IncludeScript("Admin_System/VSLib/ResponseRules.nut");
 IncludeScript("Admin_System/VSLib/RandomItemSpawner.nut");
 
 if ( __VSLIB_NOTIFY_VERSION__ )
-	printf( "Loaded VSLib version %f", __VSLIB_VERSION__ );
+	printf( "Loaded VSLib version %f - project_smok", __VSLIB_VERSION__ );

--- a/2229460523/scripts/vscripts/admin_system/vslib/entity.nut
+++ b/2229460523/scripts/vscripts/admin_system/vslib/entity.nut
@@ -310,6 +310,7 @@ getconsttable()["MOVETYPE_NOCLIP"] <- 8;		/**< No gravity, no collisions, still 
 getconsttable()["MOVETYPE_LADDER"] <- 9;		/**< Used by players only when going onto a ladder */
 getconsttable()["MOVETYPE_OBSERVER"] <- 9;		/**< Observer movement, depends on player's observer mode */
 getconsttable()["MOVETYPE_CUSTOM"] <- 10;		/**< Allows the entity to describe its own physics */
+getconsttable()["MOVETYPE_ZOMBIE_DEFAULT"] <- 11;		/** Commons' and Witch's movetype */
 
 // Flags to be used with the m_fFlags network property values
 getconsttable()["FL_ONGROUND"] <- (1 << 0);		/**< At rest / on the ground */
@@ -3373,7 +3374,7 @@ function VSLib::Entity::GetEyePosition()
  *
  * @authors shotgunefx, added optional track mask
  */
-function VSLib::Entity::GetLookingEntity(mask = 33579137)
+function VSLib::Entity::GetLookingEntity(mask = 33579137, skip_onetime_target = false)
 {
 	if (!IsEntityValid())
 	{
@@ -3381,7 +3382,7 @@ function VSLib::Entity::GetLookingEntity(mask = 33579137)
 		return;
 	}
 	
-	if("PS_ONETIME_TARGET" in GetScriptScope() && GetScriptScope().PS_ONETIME_TARGET != null && GetScriptScope().PS_ONETIME_TARGET.IsEntityValid())
+	if(!skip_onetime_target && "PS_ONETIME_TARGET" in GetScriptScope() && GetScriptScope().PS_ONETIME_TARGET != null && GetScriptScope().PS_ONETIME_TARGET.IsEntityValid())
 	{
 		return GetScriptScope().PS_ONETIME_TARGET
 	}
@@ -4752,8 +4753,8 @@ function VSLib::Entity::HasBadPhysicsModel()
 	local mdl = GetModel()
 	return ( mdl == null
 			|| mdl.find("*") != null) 
-			|| (mdl.find("hybridphysx") != null)
-			|| (mdl.find("skybox") != null)
+			|| mdl.find("hybridphysx") != null
+			|| mdl.find("skybox") != null
 }
 
 /*

--- a/2229460523/scripts/vscripts/admin_system/vslib/hud.nut
+++ b/2229460523/scripts/vscripts/admin_system/vslib/hud.nut
@@ -1087,13 +1087,13 @@ class ::VSLib.HUD.Menu extends ::VSLib.HUD.Item
 	{
 		if (typeof player != "VSLIB_PLAYER")
 		{
-			printl("[HUD-ERROR] Menu could not be displayed: a non-Player entity was passed; only VSLib.Player entities are supported.");
+			printR("[HUD-ERROR] Menu could not be displayed: a non-Player entity was passed; only VSLib.Player entities are supported.");
 			return false
 		}
 		
 		if (!player.IsEntityValid())
 		{
-			printl("[HUD-ERROR] Player is not valid.");
+			printR("[HUD-ERROR] Player is not valid.");
 			return false
 		}
 

--- a/2229460523/scripts/vscripts/admin_system/vslib/utils.nut
+++ b/2229460523/scripts/vscripts/admin_system/vslib/utils.nut
@@ -317,7 +317,7 @@ function VSLib::Utils::PrintTable(debugTable, prefix = "")
 		if ( typeof(debugTable) == "table" )
 			printl("{")
 		else if ( typeof(debugTable) == "array" )
-			printl("[")
+			printR("[")
 		prefix = "   "
 	}
 	foreach (idx, val in debugTable)

--- a/2229460523/scripts/vscripts/director_base_addon.nut
+++ b/2229460523/scripts/vscripts/director_base_addon.nut
@@ -4,6 +4,34 @@
 
 printl( "Initializing Director's script" );
 
+/* Mix red and blue colors for a better looking console message
+ * @authors rhino
+ * @param msg <string> : Message to colored print red and blue in host's console
+ * 		Expected format: [category] message
+ *			Output: {]}(BLUE) {category}(RED) {> message}(BLUE)
+ *		If format not matched: 
+ *			Output: {>>> }(RED) {message}(BLUE)
+*/
+::printR <- function(msg)
+{
+	local match = regexp(@"\[(.*)](?:.*)").search(msg)
+	if(match && match.begin == 0)
+	{
+		msg = strip(msg.slice(1))
+		local cat = msg.slice(0, msg.find("]"))
+		msg = strip(msg.slice(msg.find("]") + 1))
+		Msg("] ")
+		error(cat)
+		Msg(" > ")
+		printl(msg);
+	}
+	else
+	{
+		error(">>> ")
+		printl(msg)
+	}
+}
+
 // Include the Admin System
 IncludeScript( "admin_system" );
 

--- a/2229460523/scripts/vscripts/project_smok/adminvars.nut
+++ b/2229460523/scripts/vscripts/project_smok/adminvars.nut
@@ -130,6 +130,14 @@
     tbl._outputsEnabled <- AdminVars.RepeatValueForSurvivors(::Constants.Defaults.Tables.Outputs.State);
 }
 
+// Colorful vehicles state
+::AdminVars.SetDefaultColorfulVehiclesSettings <- function(tbl)
+{
+    tbl.ColorfulVehiclesState <- ::Constants.Defaults.Tables.ColorfulVehicles.State;
+
+    tbl.ColorfulVehiclesRanges <- ::VSLib.Utils.TableCopy(::Constants.Defaults.Tables.ColorfulVehicles.ColorRanges);
+}
+
 // Parameters for grabbing, letting go, yeeting entities
 ::AdminVars.SetDefaultGrabYeetSettings <- function(tbl)
 {
@@ -373,6 +381,8 @@
     tbl.SetDefaultParticleSettings <- ref.SetDefaultParticleSettings;
     tbl.SetDefaultExplosionSettings <- ref.SetDefaultExplosionSettings;
 
+    tbl.SetDefaultColorfulVehiclesSettings <- ref.SetDefaultColorfulVehiclesSettings;
+
     tbl.SetDefaultGrabYeetSettings <- ref.SetDefaultGrabYeetSettings;
 
     tbl.SetUpLootMakerSettings <- ref.SetUpLootMakerSettings;
@@ -411,6 +421,8 @@
 
 ::AdminVars.SetDefaultParticleSettings(::AdminVars);
 ::AdminVars.SetDefaultExplosionSettings(::AdminVars);
+
+::AdminVars.SetDefaultColorfulVehiclesSettings(::AdminVars);
 
 ::AdminVars.SetDefaultGrabYeetSettings(::AdminVars);
 

--- a/2229460523/scripts/vscripts/project_smok/messages.nut
+++ b/2229460523/scripts/vscripts/project_smok/messages.nut
@@ -31,65 +31,65 @@
                 {
                     LoadAdmins = function()
                     {
-                        //printl("[Admins] Loading admin list...");
-                        printl("\n[DEPRECATION-WARNING] admins.txt IS DEPRECATED. DELETE THE FILE AND USE user_levels.txt FROM NOW ON\n");
+                        //printR("[Admins] Loading admin list...");
+                        printR("[DEPRECATION-WARNING] admins.txt IS DEPRECATED. DELETE THE FILE AND USE user_levels.txt FROM NOW ON\n");
                     }
                     LoadScriptAuths = function()
                     {
-                        //printl("[Script-auth] Loading script authorization list...");
-                        printl("\n[DEPRECATION-WARNING] scriptauths.txt IS DEPRECATED. DELETE THE FILE AND USE user_levels.txt FROM NOW ON\n");
+                        //printR("[Script-auth] Loading script authorization list...");
+                        printR("[DEPRECATION-WARNING] scriptauths.txt IS DEPRECATED. DELETE THE FILE AND USE user_levels.txt FROM NOW ON\n");
                     }
                     LoadUserLevels = function()
                     {
-                        printl("[UserLevels] Loading user levels list...");
+                        printR("[UserLevels] Loading user levels list...");
                     }
                     LoadBanned = function()
                     {
-                        printl("[Banned] Loading ban list...");
+                        printR("[Banned] Loading ban list...");
                     }
                     LoadSettings = function()
                     {
-                        printl("[Settings] Loading settings...");
+                        printR("[Settings] Loading settings...");
                     }
                     CreateSettings = function()
                     {
-                        printl("[Settings] Creating the settings file for the first time...");
+                        printR("[Settings] Creating the settings file for the first time...");
                     }
                     LoadApocalypseSettings = function()
                     {
-                        printl("[Apocalypse-Settings] Loading apocalypse settings...");
+                        printR("[Apocalypse-Settings] Loading apocalypse settings...");
                     }
                     CreateApocalypseSettings = function()
                     {
-                        printl("[Apocalypse-Settings] Creating the setting file for the first time...");
+                        printR("[Apocalypse-Settings] Creating the setting file for the first time...");
                     }
 					LoadGhostZombiesSettings = function()
                     {
-                        printl("[Ghost_Zombies-Settings] Loading ghost zombies settings...");
+                        printR("[Ghost_Zombies-Settings] Loading ghost zombies settings...");
                     }
                     CreateGhostZombiesSettings = function()
                     {
-                        printl("[Ghost_Zombies-Settings] Creating the setting file for the first time...");
+                        printR("[Ghost_Zombies-Settings] Creating the setting file for the first time...");
                     }
                     LoadMeteorShowerSettings = function()
                     {
-                        printl("[Meteor_Shower-Settings] Loading meteor shower settings...");
+                        printR("[Meteor_Shower-Settings] Loading meteor shower settings...");
                     }
                     CreateMeteorShowerSettings = function()
                     {
-                        printl("[Meteor_Shower-Settings] Creating the setting file for the first time...");
+                        printR("[Meteor_Shower-Settings] Creating the setting file for the first time...");
                     }
                     CreateVars = function()
                     {
-                        printl("[Vars] Creating new vars table...");
+                        printR("[Vars] Creating new vars table...");
                     }
                     RestoreVars = function()
                     {
-                        printl("[Vars] Restoring existing vars table...");
+                        printR("[Vars] Restoring existing vars table...");
                     }
                     EnableSpecAndOther = function()
                     {
-                        printl("[Spectators] Enabling commands for spectator admins...");
+                        printR("[Spectators] Enabling commands for spectator admins...");
                     }
                 }
             }
@@ -100,11 +100,11 @@
                 {
                     RestoringLast = function(name,mdl)
                     {
-                        printl("[Models] Restoring last model of " + name + " to " + mdl)
+                        printR("[Models] Restoring last model of " + name + " to " + mdl)
                     }
                     RestoringOrg = function(name)
                     {
-                        printl("[Models] Restoring original model of " + name);
+                        printR("[Models] Restoring original model of " + name);
                     }
                 }
             }
@@ -404,7 +404,7 @@
             {
                 Cache = function()
                 {
-                    printl("[Cache] Caching ladder teams...");
+                    printR("[Cache] Caching ladder teams...");
                 }
 
                 Reset = function()
@@ -531,11 +531,11 @@
                 }
                 CreatingFile = function()
                 {
-                    printl("[Custom] Creating custom response file for the first time...");
+                    printR("[Custom] Creating custom response file for the first time...");
                 }
                 AddingMissingAdminTables = function(admin)
                 {
-                    printl("[Custom] Creating default response table for new admin -> " + admin);
+                    printR("[Custom] Creating default response table for new admin -> " + admin);
                 }
             }
 
@@ -735,7 +735,7 @@
 
                 FailedParticle = function()
                 {
-                    printl("[Explosion-Warning] Could not create info_particle_system entity.");
+                    printR("[Explosion-Warning] Could not create info_particle_system entity.");
                 }
 
                 FireworkLength = function()

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@
    $caller_char | _*string*_ | command caller's character name, first letter capitalized
    $caller_name | _*string*_ | command caller's in-game name
    $caller_target | _*VSLib.Entity or null*_ | entity the command caller is aiming at as a **VSLib.Entity** object or **null**
+   $specific_target | _*VSLib.Entity, VSLib.Player or null*_ | specified target by specific_target option or same as **$caller_target** if no target was given in specific_target
    
    #### Alias Options
    - There are 5 options available for aliases, none of them are required to initialize an alias.
@@ -397,6 +398,14 @@
 				//  -> Example: 4 second waiting after odd numbered repeats, 8 for even numbered ones
 				delay_between = "$[$repeat_id % 2 == 1 ? 4 : 8]"
 				
+            // Evaluate an expression to decide wheter to skip this command call
+            //  -> Example: Dont call command_2 if caller is not alive
+            skip_expression = "$[$caller_ent.IsDead()]"
+
+            // Overwrite aimed target to make the command act like you are aiming at something you are not
+            //  -> Example: Make the command act like you are aiming at yourself
+            specific_target = "self"
+
 				// Use command's caller's character name
 				arg_1 = "$caller_char"	
 				
@@ -408,6 +417,9 @@
 				
 				// Use aimed entity, if there is a valid aimed object: use it's origin vector; else: use null
 				arg_4 = "$[$caller_target ? $caller_target.GetOrigin() : null]"	
+
+				// Use target specific in specific_target option, if it's not valid use null
+				arg_5 = "$[$specific_target ? $specific_target.GetCharacterName() : null]"
 			}
 		}
 	}
@@ -2607,7 +2619,7 @@
 ### Ragdoll
 
 #### **go_ragdoll**
-- Start ragdolling with controls, hold **mouse1** to ascend, **mouse2** to descend. 
+- Start(or stop) ragdolling with controls, hold **mouse1** to ascend, **mouse2** to descend. 
 
    Minimim User Level | **PS_USER_ADMIN**
    ------------- | -------------
@@ -3075,7 +3087,7 @@
    Console Syntax | scripted_user_func *create_loot_sources,category* 
    ------------- | -------------
     
-   Menu Sequence | _6->3->9->4_
+   Menu Sequence | _6->3->9->3_
    ------------- | -------------
 ```cpp
        //Overloads:
@@ -3108,7 +3120,7 @@
    Console Syntax | scripted_user_func *show_looting_settings* 
    ------------- | -------------
     
-   Menu Sequence | _6->3->9->4->5_
+   Menu Sequence | _6->3->9->3->5_
    ------------- | -------------
 
     Setting | Default Value | Description
@@ -3143,7 +3155,7 @@
    Console Syntax | scripted_user_func *looting_setting,setting,new_value* 
    ------------- | -------------
     
-   Menu Sequence | _Command hinted at 6->3->9->4->6_
+   Menu Sequence | _Command hinted at 6->3->9->3->6_
    ------------- | -------------
 
 ```cpp
@@ -4953,6 +4965,10 @@ ExampleGnome =
    + **_custom\_responses.json_** : Custom responses, doesn't include built-in ones
 
    + **_defaults.txt_** : Default settings and parameters
+
+   + **_disable\_chat\_triggers.txt_** : Create an empty file with this name to disable **chat** triggers (**!**, **/**, **?** and **?\*** triggers are disabled)
+
+   + **_disable\_console\_commands.txt_** : Create an empty file with this name to disable **console** and **menu** commands (**scripted_user_func** console command is disabled)
 
    + **_disabled\_commands.txt_** : List of command names to disable 
 

--- a/README.md
+++ b/README.md
@@ -723,12 +723,16 @@
        // - There is also a role for host, but it can't be used with this command
        //   > PS_USER_HOST : Allow access to all commands (NOT RECOMMENDED TO BE USED FOR MORE THAN ONE PLAYER)
        user_level {character} {level: (PS_USER_NONE|PS_USER_BASIC|PS_USER_ADMIN|PS_USER_SCRIPTER)}
+       user_level {character} {level: (none|basic|admin|scripter)}
 
        // Example: Give the player playing as Bill admin privileges
        user_level bill PS_USER_ADMIN
     
+       // Example: Give the player playing as Nick scripter privileges
+       user_level nick scripter
+
        // Example: Take the player playing as Zoey's all special privileges away
-       user_level zoey PS_USER_NONE
+       user_level zoey none
 ```
 ---
 #### **command_privilege**
@@ -754,12 +758,13 @@
        //   PS_USER_SCRIPTER : Require at least scripter user privilege
        //   PS_USER_HOST : Allow access for host only
        command_privilege {command_name} {minimum_level: (PS_USER_NONE|PS_USER_BASIC|PS_USER_ADMIN|PS_USER_SCRIPTER|PS_USER_HOST)}
+       command_privilege {command_name} {level: (none|basic|admin|scripter|host)}
 
-       // Example: Give the player playing as Bill admin privileges
-       command_privilege grab PS_USER_ADMIN
+       // Example: Make grab command scripter and host only
+       command_privilege grab PS_USER_SCRIPTER
     
        // Example: They won't say no, because of the implication
-       command_privilege get_out PS_USER_HOST
+       command_privilege get_out host
 ```
 ---
 #### **reload_command_privileges**


### PR DESCRIPTION
## Additions

- Add **ColorfulVehicles** default setting to set vehicles in official maps spawned with the map have randomized colors. This is enabled by default, can be changed in **defaults.txt**.

- New alias command options: 
    + **specific_target** : Target specific command format's alias version, allows you to overwrite which object was aimed by the caller
    + **skip_expression** : An expression evaluated every command repeat to decide if current repeat should be skipped

- New alias variable **$specific_target** to allow access to entity which overwrote the aimed object. Check out the examples for more info.   

- Alias command options evaluation order is now strictly set as: **start_delay**, **repeat**, **delay_between**, **specific_target**, **skip_expression**. This determines the alias variable evaluation order as well.

- Allow disabling console(therefore menu) commands and chat triggers via creating empty files in configuration directory:
    + "**admin system/disable_console_commands.txt**": Disable console command and the menu
    + "**admin system/disable_chat_triggers.txt**": Disable chat triggers (**!, /, ?, ?\***)

- Allow shorter user level names(**PS_USER_SCRIPTER** = **scripter**, etc.)for user level related commands(**user_level**, **command_privilege**)

## Updates

- Allow **go_ragdoll** to recover the current ragdoll if there is one

- Make host's console command colored red and blue to appear more clear

- Re-add removed looting related command menus back to **6->3->9->3**

- Remove button sounds from all the **randomline** command menu elements

- Update grabbing related commands to work better with delays

- Add a slight delay to throwing related commands to decrease zero gravity chances

- Update wiki tables

- Update source code documentations

## Fixes

- Fix some of the issues of target specific command format

- Fix some small bugs